### PR TITLE
Fix docker build for gauge

### DIFF
--- a/docker/Dockerfile.gauge
+++ b/docker/Dockerfile.gauge
@@ -26,7 +26,13 @@ RUN \
   echo "deb https://packagecloud.io/grafana/stable/debian/ jessie main" > /etc/apt/sources.list.d/grafana.list
 
 RUN \
-  apt-get update ; apt-get install -qy grafana
+  apt-get update ; \
+  mkdir -p /usr/sbin/; \
+  echo "#!/bin/sh" > /usr/sbin/policy-rc.d; \
+  echo "exit 101" >> /usr/sbin/policy-rc.d; \
+  chmod 755 /usr/sbin/policy-rc.d; \
+  apt-get install -qy grafana; \
+  rm -f /usr/sbin/policy-rc.d
 
 VOLUME ["/config/"]
 WORKDIR /usr/local/lib/python2.7/dist-packages/ryu_faucet/org/onfsdn/faucet/


### PR DESCRIPTION
apt tries to start grafana during the gauge docker build and causes it to fail:

```
Failed to get D-Bus connection: Operation not permitted
dpkg: error processing package grafana (--configure):
 subprocess installed post-installation script returned error exit status 1
```

This works around apt and allows the build to succeed.