### PR TITLE
Add Dockerfiles for running locally-built faucet, and running mininet tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 *pyc
+
+dist
+
+ryu_faucet.egg-info
+
+docker/ryu-faucet-dev.tar.gz
+
+docker/tests

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ PROJECT_NAME = ryu_faucet
 DIST_DIR = dist
 SRC_DIR = src
 
+## Used by the development Dockerfile
+DOCKER_DEV_PKG = ryu-faucet-dev.tar.gz
+
 all: clobber sdist uml
 
 uml:
@@ -31,6 +34,11 @@ sdist:
 	@echo Building Python package installable via "pip"
 	$(MKDIR) $(DIST_DIR)
 	$(PYTHON) setup.py sdist
+
+dockerdev: sdist
+	@echo Copying Python package to docker/${DOCKER_DEV_PKG} for use by development Dockerfiles
+	cp ${DIST_DIR}/ryu-faucet-*.tar.gz docker/${DOCKER_DEV_PKG}
+	cp -r tests docker/
 
 codefmt:
 	@echo Run below command manually to inline replace current code with newly formatted code per “pep8” guidelines

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,21 @@
+FROM osrg/ryu
+
+RUN \
+  apt-get update && \
+  apt-get install -qy --no-install-recommends python-pip
+
+ADD ryu-faucet-dev.tar.gz /
+
+RUN \
+  pip install ipaddr; \
+  pip install /ryu-faucet-dev.tar.gz
+
+VOLUME ["/config/"]
+WORKDIR /usr/local/lib/python2.7/dist-packages/ryu_faucet/org/onfsdn/faucet/
+ENV FAUCET_CONFIG=/config/faucet.yaml
+ENV FAUCET_LOG=/config/faucet.log
+ENV FAUCET_EXCEPTION_LOG=/config/faucet-exception.log
+
+EXPOSE 6633
+
+CMD ["ryu-manager", "--verbose", "--ofp-tcp-listen-port=6633", "faucet"]

--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -1,0 +1,24 @@
+FROM osrg/ryu
+
+RUN \
+  apt-get update && \
+  apt-get install -qy --no-install-recommends python-pip vlan psmisc git sudo net-tools iputils-ping netcat-openbsd tcpdump
+
+RUN \
+  git clone git://github.com/mininet/mininet; \
+  cd mininet; \
+  git checkout -b 2.2.1 2.2.1; \
+  cd ..; \
+  mininet/util/install.sh -nfv
+
+COPY ryu-faucet-dev.tar.gz /
+COPY tests/ /tests/
+COPY runtests.sh /
+
+RUN \
+  pip install ipaddr; \
+  pip install /ryu-faucet-dev.tar.gz
+
+ENV FAUCET_DIR /usr/local/lib/python2.7/dist-packages/ryu_faucet/org/onfsdn/faucet/
+
+CMD ["/runtests.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 ## Faucet Dockerfile
 
-This directory contains two docker files **Dockerfile** and **Dockerfile.gauge**.
+This directory contains four docker files: **Dockerfile**, **Dockerfile.dev**, **Dockerfile.tests**, **Dockerfile.gauge**:
 
 ### Dockerfile
 
@@ -18,6 +18,40 @@ docker run -d --name faucet -v <path-to-config-dir>:/config/ reannz/faucet
 By default it listens on port 6633 for an OpenFlow switch to connect. Faucet expects to find the
 configuration file faucet.yaml in the config folder. If needed the -p option can be used with docker run to map ports to the host machine.
 Logs are written to /config/ for easy access from the host.
+
+### Dockerfile.dev
+
+Intended to build a container with the faucet package built using the **dockerdev** make target. To use it, first run in the top-level directory:
+
+```
+make dockerdev
+```
+
+Then, build the dev container:
+
+```
+docker build -t reannz/faucet-dev -f Dockerfile.dev .
+```
+
+Then run it, similar to the **Dockerfile** container:
+
+```
+docker run -d --name faucet-dev -v <path-to-config-dir>:/config/ reannz/faucet
+```
+
+### Dockerfile.tests
+
+Similar to **Dockerfile.dev**, this builds faucet locally, but then runs the mininet tests from the docker entrypoint:
+
+```
+make dockerdev
+cd docker/
+docker build -t reannz/faucet-tests -f Dockerfile.tests .
+apparmor_parser -R /etc/apparmor.d/usr.sbin.tcpdump
+sudo docker run --privileged -ti reannz/faucet-tests
+```
+
+The apparmor command is required on the host to allow the use of tcpdump inside the container.
 
 ### Dockerfile.gauge
 
@@ -56,4 +90,3 @@ Check the connection using test connection.
 
 From here you can add a new dashboard with and a graph pulling data from the Gauge datasource.
 See the Grafana's documentation for more on how to do this.
-

--- a/docker/runtests.sh
+++ b/docker/runtests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+service openvswitch-switch start
+cd /tests
+time python -m unittest -v faucet_mininet_test
+echo "======================================"
+export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/dist-packages/ryu_faucet/org/onfsdn/faucet/
+python test_config.py

--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -34,7 +34,7 @@ from mininet.topo import Topo
 from mininet.util import dumpNodeConnections, pmonitor
 
 
-FAUCET_DIR = '../src/ryu_faucet/org/onfsdn/faucet'
+FAUCET_DIR = os.getenv('FAUCET_DIR','../src/ryu_faucet/org/onfsdn/faucet')
 
 CONFIG_HEADER = '''
 ---

--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -18,6 +18,10 @@
 # * OVS 2.4.1 or later (Ubuntu 14 ships with 2.0.2, which is not supported)
 # * VLAN utils (vconfig, et al - on Ubuntu, apt-get install vlan)
 # * fuser
+# * net-tools
+# * iputils-ping
+# * netcat-openbsd
+# * tcpdump
 
 import ipaddr
 import os


### PR DESCRIPTION
This adds a new make target and some new docker containers:

- **Dockerfile.dev** uses the ryu-faucet package built by the new `make dockerdev` target instead of installing the current package with pip.

- **Dockerfile.tests** does the same thing as Dockerfile.dev, but runs the mininet tests as its entrypoint (it builds mininet and openvswitch, and other packages required for the unit tests).

This might not be the most elegant approach, and I'm unsure if it follows the intent of `docker/*`. Perhaps @gizmoguy and/or @rsanger could weigh in here? I'm happy to re-work this to make sense.