### PR TITLE
Tidy up the docker files and documentation slightly

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,11 +7,8 @@ RUN \
 RUN \
   pip install ryu-faucet ipaddr
 
-VOLUME ["/config/"]
+VOLUME ["/etc/opt/faucet/", "/var/log/faucet/"]
 WORKDIR /usr/local/lib/python2.7/dist-packages/ryu_faucet/org/onfsdn/faucet/
-ENV FAUCET_CONFIG=/config/faucet.yaml
-ENV FAUCET_LOG=/config/faucet.log
-ENV FAUCET_EXCEPTION_LOG=/config/faucet-exception.log
 
 EXPOSE 6633
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -10,11 +10,8 @@ RUN \
   pip install ipaddr; \
   pip install /ryu-faucet-dev.tar.gz
 
-VOLUME ["/config/"]
+VOLUME ["/etc/opt/faucet/", "/var/log/faucet/"]
 WORKDIR /usr/local/lib/python2.7/dist-packages/ryu_faucet/org/onfsdn/faucet/
-ENV FAUCET_CONFIG=/config/faucet.yaml
-ENV FAUCET_LOG=/config/faucet.log
-ENV FAUCET_EXCEPTION_LOG=/config/faucet-exception.log
 
 EXPOSE 6633
 

--- a/docker/Dockerfile.gauge
+++ b/docker/Dockerfile.gauge
@@ -34,15 +34,9 @@ RUN \
   apt-get install -qy grafana; \
   rm -f /usr/sbin/policy-rc.d
 
-VOLUME ["/config/"]
+VOLUME ["/etc/opt/faucet/", "/var/log/faucet]
 WORKDIR /usr/local/lib/python2.7/dist-packages/ryu_faucet/org/onfsdn/faucet/
 
-ENV FAUCET_CONFIG=/config/faucet.yaml
-ENV GAUGE_CONFIG=/etc/faucet/gauge.conf
-ENV FAUCET_LOG=/config/faucet.log
-ENV FAUCET_EXCEPTION_LOG=/config/faucet-exception.log
-ENV GAUGE_LOG=/config/gauge.log
-ENV GAUGE_EXCEPTION_LOG=/config/gauge-exception.log
 ADD supervisord.gauge.conf /etc/supervisor/conf.d/supervisord.conf
 ADD gauge.conf /etc/faucet/gauge.conf
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,7 @@
 ## Faucet Dockerfile
 
-This directory contains four docker files: **Dockerfile**, **Dockerfile.dev**, **Dockerfile.tests**, **Dockerfile.gauge**:
+This directory contains two docker files **Dockerfile** and
+**Dockerfile.gauge**.
 
 ### Dockerfile
 
@@ -12,11 +13,18 @@ docker build -t reannz/faucet .
 ```
 It can be run as following:
 ```
-docker run -d --name faucet -v <path-to-config-dir>:/config/ reannz/faucet
+docker run -d \
+    --name faucet \
+    -v <path-to-config-dir>:/etc/opt/faucet/ \
+    -v <path-to-logging-dir>:/var/log/faucet/ \
+    -p 6633:6633 \
+    reannz/faucet
 ```
 
-By default it listens on port 6633 for an OpenFlow switch to connect. Faucet expects to find the
-configuration file faucet.yaml in the config folder. If needed the -p option can be used with docker run to map ports to the host machine.
+By default it listens on port 6633 for an OpenFlow switch to connect. Faucet
+expects to find the configuration file faucet.yaml in the config folder. If
+needed the -e option can be used to specify the names of files with the
+FAUCET\_LOG, FAUCET\_EXCEPTION\_LOG, FAUCET\_CONFIG environment variables.
 Logs are written to /config/ for easy access from the host.
 
 ### Dockerfile.dev
@@ -36,7 +44,12 @@ docker build -t reannz/faucet-dev -f Dockerfile.dev .
 Then run it, similar to the **Dockerfile** container:
 
 ```
-docker run -d --name faucet-dev -v <path-to-config-dir>:/config/ reannz/faucet
+docker run -d \
+    --name faucet-dev \
+    -v <path-to-config-dir>:/etc/opt/faucet/ \
+    -v <path-to-logging-dir>:/var/log/faucet/ \
+    -p 6633:6633 \
+    reannz/faucet-dev
 ```
 
 ### Dockerfile.tests
@@ -55,8 +68,9 @@ The apparmor command is required on the host to allow the use of tcpdump inside 
 
 ### Dockerfile.gauge
 
-Includes faucet and gauge, including influxDB and grafana for viewing the resulting graphs.
-Consider this to be an alpha image, it does not store influx data in a persitant location.
+Includes faucet and gauge, including influxDB and grafana for viewing the
+resulting graphs.  Consider this to be an alpha image, it does not store influx
+data in a persitant location.
 
 It can be built as following:
 ```
@@ -64,29 +78,32 @@ docker build -t reannz/faucet-gauge -f Dockerfile.gauge .
 ```
 It can be run as following:
 ```
-docker run -d --name faucet -v <path-to-config-dir>:/config/ reannz/faucet-gauge
+docker run -d \
+    --name faucet \
+    -v <path-to-config-dir>:/etc/opt/faucet/ \
+    -v <path-to-logging-dir>:/var/log/faucet/ \
+    -p 6633:6633 \
+    -p 6634:6634 \
+    -p 3000:3000 \
+    reannz/faucet-gauge
 ```
 
-By default faucet listens on port 6633 and gauge on port 6634 for an OpenFlow switch. As such your switches should be configured to talk to both.
-The faucet configuration file faucet.yaml should be placed in the config directory, this also should include to configuration for guage.
+By default faucet listens on port 6633 and gauge on port 6634 for an OpenFlow
+switch. As such your switches should be configured to talk to both.  The faucet
+configuration file faucet.yaml should be placed in the config directory, this
+also should include to configuration for guage.
 
-Grafana is exposed on port 3000, and should be accessable over http from a browser.
+Grafana is exposed on port 3000, and should be accessable over http from a
+browser.
 
-#### Configuring Grafana
-First login to grafana using default credientials of User:admin Password:admin.
+#### Configuring Grafana First login to grafana using default credientials of
+User:admin Password:admin.
 
-Then connect to the influxDB, by adding it as a datasource. Use the following settings:
-```
-Name: Gauge # Or whatever you wish
-Type: InfluxDB 0.9.x
-Url: http://127.0.0.1:8086
-Access: proxy
-Http Auth: None
-Database: faucet
-User: faucet # Anything will do
-Password: faucet # Anything will do
-```
-Check the connection using test connection.
+Then connect to the influxDB, by adding it as a datasource. Use the following
+settings: ``` Name: Gauge # Or whatever you wish Type: InfluxDB 0.9.x Url:
+http://127.0.0.1:8086 Access: proxy Http Auth: None Database: faucet User:
+faucet # Anything will do Password: faucet # Anything will do ``` Check the
+connection using test connection.
 
-From here you can add a new dashboard with and a graph pulling data from the Gauge datasource.
-See the Grafana's documentation for more on how to do this.
+From here you can add a new dashboard with and a graph pulling data from the
+Gauge datasource.  See the Grafana's documentation for more on how to do this.


### PR DESCRIPTION
    Main change is removing ENV statements and instead relying on the default
    locations for relevant files. We have default values for the locations
    of config and logging files, it makes sense for docker to use these also.

    This also allows us to have the logging and config in separate directories
    while using Docker.

    Adds the -p argument to the docker README code sections as this is
    almost certainly going to be needed by anyone deploying this.

    Also makes the README fit 80 character terminals.