### PR TITLE
Reduced priority of flows for learned hosts in 2:eth_src table

### DIFF
--- a/src/ryu_faucet/org/onfsdn/faucet/valve.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/valve.py
@@ -897,7 +897,7 @@ class Valve(object):
             ofmsgs.append(self.valve_flowdrop(
                 self.dp.eth_src_table,
                 self.valve_in_match(vlan=vlan, eth_src=eth_src),
-                priority=(self.dp.highest_priority-1)))
+                priority=(self.dp.highest_priority-2)))
         else:
             learn_timeout = self.dp.timeout
             ofmsgs.extend(self.delete_host_from_vlan(eth_src, vlan))
@@ -914,10 +914,11 @@ class Valve(object):
         # but the src table rule is still being hit intermittantly the switch
         # will flood packets to that dst and not realise it needs to relearn
         # the rule
+        # NB: Must be lower than highest priority otherwise it can match flows destined to controller
         ofmsgs.append(self.valve_flowmod(
             self.dp.eth_src_table,
             self.valve_in_match(in_port=in_port, vlan=vlan, eth_src=eth_src),
-            priority=self.dp.highest_priority,
+            priority=self.dp.highest_priority-1,
             inst=[self.goto_table(self.dp.eth_dst_table)],
             hard_timeout=learn_timeout))
 


### PR DESCRIPTION
If the flows added by learn_host_on_vlan_port() matching on eth_src have 
priority=self.db.highest_priority they can match packets destined to the controller,
which are supposed to match the flows added by learn_host_on_vlan_port().
I think that the former should have lower priority (self.db.high_priority maybe?
right now I just put a "-1").