### PR TITLE
Add new configuration format with support for multiple datapaths

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,86 @@ The datapath ID may be specified as an integer or hex string (beginning with 0x)
 
 A port not explicitly defined in the YAML configuration file will be set down and will drop all packets.
 
+
+Versions
+--------
+
+The Faucet configuration file format occasionally changes to add functionality or accomodate changes inside Faucet. If the ``version`` field is not specified in ``faucet.yaml``, the current default value is ``1``.
+
+Version 1 of the Faucet configuration file format does not allow multiple datapaths to be defined. The one datapath configured for this Faucet instance is configured using top level values, a sample of which can be found in ``faucet.yaml``. Previous (1.0 and older) versions of Faucet do not support the ``version`` field, so most configuration files in this format should not use it, unless using a newer version of Faucet with an older configuration file is required.
+
+.. code:: yaml
+
+  ---
+  dp_id: 0x000000000001:
+  name: "test-switch-1"
+  
+  interfaces:
+      1:
+          native_vlan: 2040
+          acl_in: 1
+
+  vlans:
+      2040:
+          name: "dev VLAN"
+
+  acls:
+      1:
+          - rule:
+              nw_dst: "172.0.0.0/8"
+              dl_type: 0x800
+              allow: 1
+
+          - rule:
+              dl_type: 0x0806
+              allow: 1
+
+          - rule:
+              nw_dst: "10.0.0.0/16"
+              dl_type: 0x800
+              allow: 0
+
+Version 2 of the Faucet configuration file format adds the ``version`` field, and allows multiple datapaths (switches) to be defined in one configuration file using the ``dps`` object, with each datapath sharing the ``vlans`` and ``acls`` objects defined in that file.
+
+.. code:: yaml
+
+  ---
+  version: 2
+
+  dps:
+      0x000000000001:
+          name: "test-switch-1"
+          interfaces:
+              1:
+                  native_vlan: 2040
+                  acl_in: 1
+      0x000000000002:
+          name: "test-switch-2"
+          interfaces:
+              1:
+                  native_vlan: 2040
+                  acl_in: 1
+
+  vlans:
+      2040:
+          name: "dev VLAN"
+
+  acls:
+      1:
+          - rule:
+              nw_dst: "172.0.0.0/8"
+              dl_type: 0x800
+              allow: 1
+
+          - rule:
+              dl_type: 0x0806
+              allow: 1
+
+          - rule:
+              nw_dst: "10.0.0.0/16"
+              dl_type: 0x800
+              allow: 0
+
 ============
 Installation
 ============

--- a/src/ryu_faucet/org/onfsdn/faucet/dp.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/dp.py
@@ -42,23 +42,11 @@ class DP(object):
         self.set_defaults()
 
     @classmethod
-    def parser(cls, config_file, logname=__name__):
+    def _parser_v1(cls, conf, logname):
         logger = logging.getLogger(logname)
-        try:
-            with open(config_file, 'r') as stream:
-                conf = yaml.load(stream)
-        except yaml.YAMLError as ex:
-            mark = ex.problem_mark
-            errormsg = "Error in file: {0} at ({1}, {2})".format(
-                config_file,
-                mark.line + 1,
-                mark.column + 1)
-            logger.error(errormsg)
-            return None
 
         if 'dp_id' not in conf:
-            errormsg = "dp_id not configured in file: {0}".format(config_file)
-            logger.error(errormsg)
+            logger.error("dp_id not configured in file: {0}".format(config_file))
             return None
 
         dp = DP(conf['dp_id'], logname)
@@ -76,8 +64,64 @@ class DP(object):
         for acl_num, acl_conf in acls.iteritems():
             dp.add_acl(acl_num, acl_conf)
 
-
         return dp
+
+    @classmethod
+    def _parser_v2(cls, conf, logname):
+        logger = logging.getLogger(logname)
+
+        if 'dps' not in conf:
+            logger.error("dps not configured in file: {0}".format(config_file))
+            return None
+
+        vlans = conf.pop('vlans', {})
+        acls = conf.pop('acls', {})
+
+        dps = []
+        for dp_id, cf in conf['dps'].iteritems():
+            dp = DP(dp_id, logname)
+            interfaces = cf.pop('interfaces', {})
+            dp.__dict__.update(cf)
+            dp.set_defaults()
+
+            for vid, vlan_conf in vlans.iteritems():
+                dp.add_vlan(vid, vlan_conf)
+            for port_num, port_conf in interfaces.iteritems():
+                dp.add_port(port_num, port_conf)
+            for acl_num, acl_conf in acls.iteritems():
+                dp.add_acl(acl_num, acl_conf)
+
+            dps.append(dp)
+
+        if dps:
+            return dps[0]
+        else:
+            logger.error("dps configured with no elements in file: {0}".format(config_file))
+            return None
+
+    @classmethod
+    def parser(cls, config_file, logname=__name__):
+        logger = logging.getLogger(logname)
+        try:
+            with open(config_file, 'r') as stream:
+                conf = yaml.load(stream)
+        except yaml.YAMLError as ex:
+            mark = ex.problem_mark
+            logger.error("Error in file: {0} at ({1}, {2})".format(
+                config_file,
+                mark.line + 1,
+                mark.column + 1))
+            return None
+
+        version = conf.pop('version', 1)
+
+        if version == 1:
+            return DP._parser_v1(conf, logname)
+        elif version == 2:
+            return DP._parser_v2(conf, logname)
+        else:
+            logger.error("unsupported config version number: {0}".format(version))
+            return None
 
     def sanity_check(self):
         assert 'dp_id' in self.__dict__


### PR DESCRIPTION
Partially addresses issue #112, by implementing the configuration file format changes needed to support multiple datapaths. Also adds some documentation on the changes made.

Everything should work fine but any additional testing and comments would be appreciated. I can add any additional features while I'm at it, if you like.

This change is backwards compatible with existing configuration files by adding a `version` field which defaults to `1` (the original format), so this should be safe to merge.