### PR TITLE
Implement BGP advertisement of controller IPs and static routes.

### DIFF
--- a/src/ryu_faucet/org/onfsdn/faucet/vlan.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/vlan.py
@@ -35,6 +35,16 @@ class VLAN(object):
             self.controller_ips = [
                 ipaddr.IPNetwork(ip) for ip in self.controller_ips]
         self.unicast_flood = conf.setdefault('unicast_flood', True)
+        self.bgp_as = conf.setdefault('bgp_as', 0)
+        self.bgp_port = conf.setdefault('bgp_port', 9179)
+        self.bgp_routerid = conf.setdefault('bgp_routerid', '')
+        self.bgp_neighbor_address = conf.setdefault('bgp_neighbor_address', '')
+        self.bgp_neighbor_as = conf.setdefault('bgp_neighbor_as', 0)
+        if self.bgp_as:
+            assert self.bgp_port
+            assert ipaddr.IPv4Address(self.bgp_routerid)
+            assert ipaddr.IPAddress(self.bgp_neighbor_address)
+            assert self.bgp_neighbor_as
         self.routes = conf.setdefault('routes', {})
         self.ipv4_routes = {}
         self.ipv6_routes = {}


### PR DESCRIPTION
IPv4 and IPv6 is implemented.

This is intended to serve as a "northbound" API for an external
system to import/export routes to/from FAUCET, since FAUCET
can do nexthop resolution for IPv4 and IPv6 itself - for example,
Quagga running on the host colocated with the controller. The
external system should do all necessary route filtering.

BGP is implemented per VLAN (bgp_port is what TCP port FAUCET
will listen on - must be different per VLAN).

vlans:
    100:
        bgp_port: 9179
        bgp_as: 1
        bgp_routerid: '1.1.1.1'
        bgp_neighbor_address: '127.0.0.1'
        bgp_neighbor_as: 2

Restrictions:

* bgp_routerid must be an IPv4 address, even when peering over IPv6.

* Only one neighbor is supported (since intended use is an API).

* Receiving routes is not yet implemented.

* Port status updating advertisements is not yet implemented.

* FAUCET does not peer with peers in the dataplane; it can peer only
with peers reachable by the controller itself. To peer with hosts in
the dataplane, use a trunk/offload port that bridges the dataplane
to the controller.