### PR TITLE
Fix building of gauge Dockerfile.

### DIFF
--- a/Dockerfile.gauge
+++ b/Dockerfile.gauge
@@ -2,12 +2,13 @@ FROM osrg/ryu
 
 RUN \
   apt-get update && \
-  apt-get install -qy --no-install-recommends python-pip supervisor \
+  apt-get install -qy --no-install-recommends wget python-pip supervisor \
     apt-transport-https libyaml-dev libpython2.7-dev
 
 COPY ./ /faucet-src/
 
 RUN \
+  pip install wheel && \
   pip install influxdb && \
   pip install /faucet-src
 


### PR DESCRIPTION
Install 'wheel' pip package manually to supress errors.
Install wget apt package so that Docker can be built.