### PR TITLE
Complete BGP support.

### DIFF
--- a/src/ryu_faucet/org/onfsdn/faucet/faucet.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/faucet.py
@@ -128,12 +128,12 @@ class Faucet(app_manager.RyuApp):
                      self.logger.error('BGP nexthop %s for prefix %s cannot be us' % (nexthop, prefix))
                  elif withdraw:
                      self.logger.info('BGP withdraw %s nexthop %s' % (prefix, nexthop))
-                     ryudp = self.dpset.get(self.dp.dp_id)
-                     flowmods = self.valve.del_route(vlan, prefix, nexthop)
+                     flowmods = self.valve.del_route(vlan, nexthop, prefix)
+                     ryudp = self.dpset.get(self.valve.dp.dp_id)
                      self.send_flow_msgs(ryudp, flowmods)
                  else:
                      self.logger.info('BGP add %s nexthop %s' % (prefix, nexthop))
-                     self.valve.add_route(vlan, prefix, nexthop)
+                     self.valve.add_route(vlan, nexthop, prefix)
                  return
         self.logger.error(
             'BGP nexthop %s for prefix %s is not a connected network' % (
@@ -141,6 +141,7 @@ class Faucet(app_manager.RyuApp):
 
     def reset_bgp(self):
         # TODO: port status changes should cause us to withdraw a route.
+        # TODO: configurable behavior - withdraw routes if peer goes down.
         for bgp_speaker in self.bgp_speakers.itervalues():
             bgp_speaker.shutdown()
         for vlan in self.valve.dp.vlans.itervalues():

--- a/src/ryu_faucet/org/onfsdn/faucet/valve.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/valve.py
@@ -758,6 +758,30 @@ class Valve(object):
             pkt.add_protocol(eth_pkt)
         return pkt
 
+    def add_route(self, vlan, ip_gw, ip_dst):
+        if ip_dst.version == 6:
+            vlan.ipv6_routes[ip_dst] = ip_gw
+        else:
+            vlan.ipv4_routes[ip_dst] = ip_gw
+
+    def del_route(self, vlan, ip_gw, ip_dst):
+        ofmsgs = []
+        if ip_dst.version == 6:
+            if ip_dst not in vlan.ipv6_routes:
+                del vlan.ipv6_routes[ip_dst]
+                route_match = self.valve_in_match(
+                    vlan=vlan, nw_dst=ip_dst, eth_dst=self.FAUCET_MAC)
+                ofmsgs.append(self.valve_flowdel(
+                    self.dp.eth_src_table, route_match))
+        else:
+            if ip_dst not in vlan.ipv4_routes:
+                del vlan.ipv4_routes[ip_dst]
+                route_match = self.valve_in_match(
+                    vlan=vlan, nw_dst=ip_dst, eth_dst=self.FAUCET_MAC)
+                ofmsgs.append(self.valve_flowdel(
+                    self.dp.eth_src_table, route_match))
+        return ofmsgs
+
     def add_resolved_route(self, eth_type, vlan, neighbor_cache,
                            ip_gw, ip_dst, eth_dst, is_updated=None):
         ofmsgs = []

--- a/src/ryu_faucet/org/onfsdn/faucet/valve.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/valve.py
@@ -759,25 +759,33 @@ class Valve(object):
         return pkt
 
     def add_route(self, vlan, ip_gw, ip_dst):
+        # TODO: retrigger nexthop resolution on every new route
+        # could be optimized.
         if ip_dst.version == 6:
             vlan.ipv6_routes[ip_dst] = ip_gw
+            if ip_gw in vlan.nd_cache:
+                del vlan.nd_cache[ip_gw]
         else:
             vlan.ipv4_routes[ip_dst] = ip_gw
+            if ip_gw in vlan.arp_cache:
+                del vlan.arp_cache[ip_gw]
 
     def del_route(self, vlan, ip_gw, ip_dst):
         ofmsgs = []
         if ip_dst.version == 6:
-            if ip_dst not in vlan.ipv6_routes:
+            if ip_dst in vlan.ipv6_routes:
                 del vlan.ipv6_routes[ip_dst]
                 route_match = self.valve_in_match(
-                    vlan=vlan, nw_dst=ip_dst, eth_dst=self.FAUCET_MAC)
+                    vlan=vlan, eth_type=ether.ETH_TYPE_IPV6,
+                    nw_dst=ip_dst, eth_dst=self.FAUCET_MAC)
                 ofmsgs.append(self.valve_flowdel(
                     self.dp.eth_src_table, route_match))
         else:
-            if ip_dst not in vlan.ipv4_routes:
+            if ip_dst in vlan.ipv4_routes:
                 del vlan.ipv4_routes[ip_dst]
                 route_match = self.valve_in_match(
-                    vlan=vlan, nw_dst=ip_dst, eth_dst=self.FAUCET_MAC)
+                    vlan=vlan, eth_type=ether.ETH_TYPE_IP,
+                    nw_dst=ip_dst, eth_dst=self.FAUCET_MAC)
                 ofmsgs.append(self.valve_flowdel(
                     self.dp.eth_src_table, route_match))
         return ofmsgs

--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -1234,10 +1234,14 @@ vlans:
         self.setup_ipv6_hosts_addresses(
             first_host, first_host_ip, first_host_routed_ip,
             second_host, second_host_ip, second_host_routed_ip)
+        self.wait_until_matching_flow('fc00::20:')
         self.verify_ipv6_routing(
             first_host, first_host_ip, first_host_routed_ip,
             second_host, second_host_ip, second_host_routed_ip)
         self.swap_host_macs(first_host, second_host)
+        self.setup_ipv6_hosts_addresses(
+            first_host, first_host_ip, first_host_routed_ip,
+            second_host, second_host_ip, second_host_routed_ip)
         self.verify_ipv6_routing(
             first_host, first_host_ip, first_host_routed_ip,
             second_host, second_host_ip, second_host_routed_ip)


### PR DESCRIPTION
FAUCET can now can receive and announce routes over BGP, both IPv4 and IPv6.

FAUCET will install routes its in FIB from the external peer, provided that the nexthop is in the same subnet as one of the VLANs' IP addresses. FAUCET will do the nexthop resolution itself.

See FaucetUntaggedBGPIPv4RouteTest and FaucetUntaggedBGPIPv6RouteTests for examples of how to send routes to FAUCET (using exabgp in this instance).
