### PR TITLE
Fix a (serious) mistake: missing fib_table argument in add_route

### DIFF
--- a/src/ryu_faucet/org/onfsdn/faucet/valve.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/valve.py
@@ -786,16 +786,18 @@ class Valve(object):
             routes = vlan.ipv6_routes
             neighbor_cache = vlan.nd_cache
             eth_type = ether.ETH_TYPE_IPV6
+            fib_table = self.dp.ipv6_fib_table
         else:
             routes = vlan.ipv4_routes
             neighbor_cache = vlan.arp_cache
             eth_type = ether.ETH_TYPE_IP
+            fib_table = self.dp.ipv4_fib_table
         routes[ip_dst] = ip_gw
         if ip_gw in neighbor_cache:
             eth_dst = neighbor_cache[ip_gw].eth_src
             ofmsgs.extend(
                     self.add_resolved_route(
-                        eth_type=eth_type,vlan=vlan,
+                        eth_type=eth_type,fib_table=fib_table,vlan=vlan,
                         neighbor_cache=neighbor_cache,
                         ip_gw=ip_gw,ip_dst=ip_dst,
                         eth_dst=eth_dst,is_updated=False))


### PR DESCRIPTION
This shouldn't have passed the test :)
I'm trying to figure out how to write a unitest for add_route (when next-hop is resolved) and del_route
I added "process" to exabgp to program the bgp updates, but it does not work. Somehow, exabgp says "permission denied" when the control script is placed inside a temp dir.