### PR TITLE
Openvswitch module must be loaded on the docker host for tests to run.

### DIFF
--- a/README.docker.md
+++ b/README.docker.md
@@ -69,6 +69,7 @@ This runs the mininet tests from the docker entry-point:
 ```
 docker build -t reannz/faucet-tests -f Dockerfile.tests .
 apparmor_parser -R /etc/apparmor.d/usr.sbin.tcpdump
+modprobe openvswitch
 sudo docker run --privileged -ti reannz/faucet-tests
 ```
 


### PR DESCRIPTION
Add extra command to help file that tells you how to run the Docker tests to make it clear that openvswitch module must be loaded prior to the Docker being started.