### PR TITLE
Don't crash faucet if someone plugs a cable into an unconfigured port.

### DIFF
--- a/src/ryu_faucet/org/onfsdn/faucet/valve.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/valve.py
@@ -747,8 +747,8 @@ class Valve(object):
 
         if port_num not in self.dp.ports:
             self.logger.info(
-                'Autoconfiguring port:%u based on default config', port_num)
-            self.dp.add_port(port_num)
+                'Ignoring port:%u not present in configuration file', port_num)
+            return []
 
         port = self.dp.ports[port_num]
         self.logger.info('Port %s added', port)


### PR DESCRIPTION
At the moment we silently crash if someone plugs a cable into a faucet
controlled switch that isn't listed in the config file.

This bug is caused by old code leftover from Valve. I think this is bad
default behaviour so have removed the old code.