### PR TITLE
changes to docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: '2'
 services:
     db:
+        restart: always
         image: 'tutum/influxdb:latest'
         ports:
             - '8086'
@@ -13,16 +14,20 @@ services:
             INFLUXDB_INIT_PWD: 'faucet'
 
     grafana:
+        restart: always
         image: 'grafana/grafana:latest'
         ports:
             - '3000:3000'
+        volumes:
+            - '/opt/grafana:/var/lib/grafana'
         links:
             - db
 
     gauge:
-        build:
-            context: ./
-            dockerfile: 'Dockerfile.gauge'
+        restart: always
+        image: 'faucet/gauge:latest'
+        environment:
+           - GAUGE_CONFIG=/etc/ryu/faucet/gauge.yaml
         volumes:
             - '/var/log/ryu/faucet:/var/log/ryu/faucet'
             - '/etc/ryu/faucet:/etc/ryu/faucet'
@@ -30,3 +35,13 @@ services:
             - '6634:6633'
         links:
             - db
+
+    faucet:
+        restart: always
+        image: 'faucet/faucet:latest'
+        volumes:
+            - '/var/log/ryu/faucet:/var/log/ryu/faucet'
+            - '/etc/ryu/faucet:/etc/ryu/faucet'
+        ports:
+            - '6633:6633'
+


### PR DESCRIPTION
I noticed the following when trying to use the existing docker-compose.yaml:

The config file for gauge wasn't pointing at the new yaml one.  Fixed with an env var
The grafana data wasn't persistant.  Fixed with a bind mount to the file system (yes there are other ways to do this but there you go)
The containers didn't restart if they failed.  They do now with restart: always
Faucet wasn't being started (as gauge and faucet have been split now).  If people don't want it started then it's easier for them to remove it from the example than it is for other people to work out how to add it.
