### PR TITLE
Add support for required and optional include files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,6 +177,36 @@ Version 2 of the Faucet configuration file format adds the ``version`` field, an
               dl_type: 0x800
               allow: 0
 
+Extra DP, VLAN or ACL data can also be separated into different files and included into the main configuration file, as shown below. The ``include`` field is used for configuration files which are required to be loaded, and Faucet will log an error if there was a problem while loading a file. Files listed on ``include-optional`` will simply be skipped and a warning will be logged instead.
+
+Files are parsed in order, and both absolute and relative (to the configuration file) paths are allowed. DPs, VLANs or ACLs defined in subsequent files overwrite previously defined ones with the same name.
+
+faucet.yaml:
+
+.. code:: yaml
+
+  ---
+  version: 2
+
+  include:
+      - /etc/ryu/faucet/dps.yaml
+      - /etc/ryu/faucet/vlans.yaml
+
+  include-optional:
+      - acls.yaml
+
+dps.yaml:
+
+.. code:: yaml
+
+  ---
+  dps:
+      test-switch-1:
+          ...
+      test-switch-2:
+          ...
+
+
 ============
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -200,6 +200,11 @@ dps.yaml:
 .. code:: yaml
 
   ---
+  # Recursive include is allowed, if needed.
+  # Again, relative paths are relative to this configuration file.
+  include-optional:
+      - override.yaml
+
   dps:
       test-switch-1:
           ...

--- a/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
@@ -118,15 +118,13 @@ def _dp_include(parent_file, config_file, dps_conf, vlans_conf, acls_conf, logna
     )
 
     if not os.path.isfile(cf):
-        logger.warning("not a regular file or does not exist: {0}".format(
-            cf))
+        logger.warning("not a regular file or does not exist: {0}".format(cf))
         return False
 
     conf = read_config(cf, logname)
 
     if not conf:
-        logger.warning("error loading config from file: {0}".format(
-            cf))
+        logger.warning("error loading config from file: {0}".format(cf))
         return False
 
     dps_conf.update(conf.pop('dps', {}))

--- a/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
@@ -134,7 +134,7 @@ def _dp_include(parent_file, config_file, dps_conf, vlans_conf, acls_conf, logna
     for cf in conf.pop('include', []):
         if not _dp_include(config, cf, dps_conf, vlans_conf, acls_conf, logname):
             logger.error("unable to load required include file: {0}".format(cf))
-            return None
+            return False
 
     for cf in conf.pop('include-optional', []):
         if not _dp_include(config, cf, dps_conf, vlans_conf, acls_conf, logname):
@@ -166,7 +166,9 @@ def _dp_parser_v2(conf, config_file, logname):
     vlans_conf = {}
     acls_conf = {}
 
-    _dp_include(None, config_file, dps_conf, vlans_conf, acls_conf, logname)
+    if not _dp_include(None, config_file, dps_conf, vlans_conf, acls_conf, logname):
+        logger.error("error found while loading config file: {0}".format(config_file))
+        return None
 
     if not dps_conf:
         logger.error("dps not configured in file: {0}".format(config_file))

--- a/tests/config/testconfigv2-acls.yaml
+++ b/tests/config/testconfigv2-acls.yaml
@@ -1,0 +1,11 @@
+---
+acls:
+    acl1:
+        - rule:
+            nw_dst: '172.0.0.0/8'
+            dl_type: 0x800
+            actions:
+                allow: 1
+        - rule:
+            actions:
+                allow: 0

--- a/tests/config/testconfigv2-dps.yaml
+++ b/tests/config/testconfigv2-dps.yaml
@@ -1,0 +1,26 @@
+---
+dps:
+    switch1:
+        dp_id: 0xcafef00d
+        hardware: 'Open vSwitch'
+        interfaces:
+            port1:
+                number: 1
+                tagged_vlans: ['v40', 41]
+                acl_in: 'acl1'
+            2:
+                native_vlan: 'v40'
+            port3:
+                number: 3
+                native_vlan: 'v40'
+                tagged_vlans: [41]
+            port4:
+                number: 4
+                native_vlan: 41
+            port5:
+                number: 5
+                native_vlan: 41
+                permanent_learn: True
+            port6:
+                number: 6
+                mirror: 'port1'

--- a/tests/config/testconfigv2-dps.yaml
+++ b/tests/config/testconfigv2-dps.yaml
@@ -1,4 +1,8 @@
 ---
+# test recursive include
+include:
+    - testconfigv2-vlans.yaml
+
 dps:
     switch1:
         dp_id: 0xcafef00d

--- a/tests/config/testconfigv2-vlans.yaml
+++ b/tests/config/testconfigv2-vlans.yaml
@@ -1,0 +1,24 @@
+---
+vlans:
+    v40:
+        vid: 40
+        unicast_flood: False
+        max_hosts: 20
+    41:
+        name: 'v41'
+        controller_ips: ['10.0.0.253/24']
+        bgp_port: 9179
+        bgp_as: 1
+        bgp_routerid: '1.1.1.1'
+        bgp_neighbor_address: '127.0.0.1'
+        bgp_neighbor_as: 2
+        routes:
+            - route:
+                ip_dst: '10.0.1.0/24'
+                ip_gw: '10.0.0.1'
+            - route:
+                ip_dst: '10.0.2.0/24'
+                ip_gw: '10.0.0.2'
+            - route:
+                ip_dst: '10.0.3.0/24'
+                ip_gw: '10.0.0.2'

--- a/tests/config/testconfigv2.yaml
+++ b/tests/config/testconfigv2.yaml
@@ -1,15 +1,16 @@
 ---
 version: 2
 
+# test include
 include:
     - testconfigv2-dps.yaml
-    - testconfigv2-vlans.yaml
 
+# test include-optional
 include-optional:
     - testconfigv2-acls.yaml
 
+# overwritten in testconfigv2-acls.yaml
 acls:
-    # overwritten in testconfigv2-acls.yaml
     acl1:
         - rule:
             nw_dst: '10.0.0.0/8'

--- a/tests/config/testconfigv2.yaml
+++ b/tests/config/testconfigv2.yaml
@@ -1,57 +1,18 @@
 ---
 version: 2
-dps:
-    switch1:
-        dp_id: 0xcafef00d
-        hardware: 'Open vSwitch'
-        interfaces:
-            port1:
-                number: 1
-                tagged_vlans: ['v40', 41]
-                acl_in: 'acl1'
-            2:
-                native_vlan: 'v40'
-            port3:
-                number: 3
-                native_vlan: 'v40'
-                tagged_vlans: [41]
-            port4:
-                number: 4
-                native_vlan: 41
-            port5:
-                number: 5
-                native_vlan: 41
-                permanent_learn: True
-            port6:
-                number: 6
-                mirror: 'port1'
-vlans:
-    v40:
-        vid: 40
-        unicast_flood: False
-        max_hosts: 20
-    41:
-        name: 'v41'
-        controller_ips: ['10.0.0.253/24']
-        bgp_port: 9179
-        bgp_as: 1
-        bgp_routerid: '1.1.1.1'
-        bgp_neighbor_address: '127.0.0.1'
-        bgp_neighbor_as: 2
-        routes:
-            - route:
-                ip_dst: '10.0.1.0/24'
-                ip_gw: '10.0.0.1'
-            - route:
-                ip_dst: '10.0.2.0/24'
-                ip_gw: '10.0.0.2'
-            - route:
-                ip_dst: '10.0.3.0/24'
-                ip_gw: '10.0.0.2'
+
+include:
+    - testconfigv2-dps.yaml
+    - testconfigv2-vlans.yaml
+
+include-optional:
+    - testconfigv2-acls.yaml
+
 acls:
+    # overwritten in testconfigv2-acls.yaml
     acl1:
         - rule:
-            nw_dst: '172.0.0.0/8'
+            nw_dst: '10.0.0.0/8'
             dl_type: 0x800
             actions:
                 allow: 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,7 +31,7 @@ class DistConfigTestCase(unittest.TestCase):
     def setUp(self):
         logname = 'test_config'
 
-        logger = logging.getLogger("%s.config" % logname)
+        logger = logging.getLogger('%s.config' % logname)
         logger_handler = logging.StreamHandler(stream=sys.stderr)
         log_fmt = '%(asctime)s %(name)-6s %(levelname)-8s %(message)s'
         logger_handler.setFormatter(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -143,6 +143,7 @@ class DistConfigTestCase(unittest.TestCase):
         for dp in (self.v1_dp, self.v2_dp):
             self.assertIn(1, dp.acl_in)
             self.assertIn(dp.ports[1].acl_in, dp.acls)
+            self.assertEquals(dp.acls[dp.ports[1].acl_in][0]['nw_dst'], '172.0.0.0/8')
 
     def test_gauge_port_stats(self):
         for watcher in self.v1_watchers:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import sys
 import os
 import ipaddr
@@ -28,12 +29,23 @@ from config_parser import dp_parser, watcher_parser
 
 class DistConfigTestCase(unittest.TestCase):
     def setUp(self):
-        self.v1_dp = dp_parser('config/testconfig.yaml', 'test_config')[0]
-        self.v2_dp = dp_parser('config/testconfigv2.yaml', 'test_config')[0]
+        logname = 'test_config'
+
+        logger = logging.getLogger("%s.config" % logname)
+        logger_handler = logging.StreamHandler(stream=sys.stderr)
+        log_fmt = '%(asctime)s %(name)-6s %(levelname)-8s %(message)s'
+        logger_handler.setFormatter(
+            logging.Formatter(log_fmt, '%b %d %H:%M:%S'))
+        logger.addHandler(logger_handler)
+        logger.propagate = 0
+        logger.setLevel(logging.WARNING)
+
+        self.v1_dp = dp_parser('config/testconfig.yaml', logname)[0]
+        self.v2_dp = dp_parser('config/testconfigv2.yaml', logname)[0]
         self.v1_watchers = watcher_parser(
-            'config/testgaugeconfig.conf', 'test_config')
+            'config/testgaugeconfig.conf', logname)
         self.v2_watchers = watcher_parser(
-            'config/testgaugeconfig.yaml', 'test_config')
+            'config/testgaugeconfig.yaml', logname)
 
     def test_dps(self):
         for dp in (self.v1_dp, self.v2_dp):


### PR DESCRIPTION
Adds functionality, documentation and tests for allowing DPs, VLANs and ACLs to be defined in separate/additional configuration files.

Basically, an `include` and `include-optional` section were both added, which both are lists of either absolute or relative (to the config file) paths, and the configuration dictionary from the main configuration is updated with that of the included files. Files are parsed in this order: main configuration file, required include files, optional include files (both in the list order they are defined in). Duplicate DPs/VLANs/ACLs get replaced with the last one read.

See the commits for more details.