### PR TITLE
Make tests more robust when we get a bad JSON reply.

### DIFF
--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -343,8 +343,13 @@ hardware: "%s"
     def wait_until_matching_flow(self, exp_flow, timeout=10):
         for _ in range(timeout):
             int_dpid = str_int_dpid(self.dpid)
-            ofctl_result = json.loads(requests.get(
-                '%s/stats/flow/%s' % (self.ofctl_rest_url(), int_dpid)).text)
+            try:
+                ofctl_result = json.loads(requests.get(
+                    '%s/stats/flow/%s' % (self.ofctl_rest_url(), int_dpid)).text)
+            except ValueError:
+                # Didn't get valid JSON, try again
+                time.sleep(1)
+                continue
             dump_flows = ofctl_result[int_dpid]
             for flow in dump_flows:
                 # Re-transform the dictionary into str to re-use


### PR DESCRIPTION
At the moment a single bad response from the ofctl REST API will cause us to fail a test.

Make this more robust by catching ValueError (parsing) exceptions and doing our normal timeout business.

This should make tests slightly more reliable on non-docker systems. I'm still tracking down a few other issues to make this fully reliable.