### PR TITLE
Rework ordering of tcpdump tests.

### DIFF
--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -1051,14 +1051,12 @@ acls:
         tcpdump_filter = 'not ether src %s and icmp' % mirror_mac
         tcpdump_out = mirror_host.popen(
             'timeout 10s tcpdump -n -v -c 2 -U %s' % tcpdump_filter)
-        # wait for tcpdump to start
-        time.sleep(1)
         popens = {mirror_host: tcpdump_out}
-        first_host.cmd('ping -c1  %s' % second_host.IP())
         tcpdump_txt = ''
         for host, line in pmonitor(popens):
             if host == mirror_host:
                 tcpdump_txt += line.strip()
+            first_host.cmd('ping -c1  %s' % second_host.IP())
         self.assertFalse(tcpdump_txt == '')
         self.assertTrue(re.search(
             '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
@@ -1106,15 +1104,13 @@ acls:
             'icmp and ether dst 06:06:06:06:06:06')
         tcpdump_out = second_host.popen(
             'timeout 10s tcpdump -e -n -v -c 2 -U %s' % tcpdump_filter)
-        # wait for tcpdump to start
-        time.sleep(1)
         popens = {second_host: tcpdump_out}
-        first_host.cmd('arp -s %s %s' % (second_host.IP(), '01:02:03:04:05:06'))
-        first_host.cmd('ping -c1  %s' % second_host.IP())
         tcpdump_txt = ''
         for host, line in pmonitor(popens):
             if host == second_host:
                 tcpdump_txt += line.strip()
+            first_host.cmd('arp -s %s %s' % (second_host.IP(), '01:02:03:04:05:06'))
+            first_host.cmd('ping -c1  %s' % second_host.IP())
         self.assertFalse(tcpdump_txt == '')
         self.assertTrue(re.search(
             '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
@@ -1153,14 +1149,12 @@ vlans:
         tcpdump_filter = 'not ether src %s and icmp' % mirror_mac
         tcpdump_out = mirror_host.popen(
             'timeout 10s tcpdump -n -v -c 2 -U %s' % tcpdump_filter)
-        # wait for tcpdump to start
-        time.sleep(1)
         popens = {mirror_host: tcpdump_out}
-        first_host.cmd('ping -c1  %s' % second_host.IP())
         tcpdump_txt = ''
         for host, line in pmonitor(popens):
             if host == mirror_host:
                 tcpdump_txt += line.strip()
+            first_host.cmd('ping -c1  %s' % second_host.IP())
         self.assertFalse(tcpdump_txt == '')
         self.assertTrue(re.search(
             '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))


### PR DESCRIPTION
On slower systems the 1 second sleep might not be long enough to start tcpdump and have it capturing packets before we inject the test packets.

Move the packet creation into the output check loop so that we retry sending test packets if tcpdump doesn't get them the first time.

This approach still isn't 100% perfect, ideally we would be able to poll tcpdump to work out when it's ready and capturing packets, but I couldn't find a reliable way of doing this.