### PR TITLE
Add cleanup mode for unit tests to cleanup after failed runs.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -3,6 +3,11 @@ Faucet Test tool
 
 This tool is to test Faucet functions using OpenFlow 1.3 OpenVSwitch on Mininet.
 
+If you interrupt the test process or it crashes during testing interfaces, processes and openvswitch configuration used for testing
+may be left over on the system. You can run the test script in cleanup mode to tidy the system of leftover mininet objects:
+
+```$ sudo ./faucet_mininet_test.py --clean```
+
 
 Requirement(s)
 ------------------------

--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -49,6 +49,7 @@ from mininet.node import Intf
 from mininet.node import OVSSwitch
 from mininet.topo import Topo
 from mininet.util import dumpNodeConnections, pmonitor
+from mininet.clean import Cleanup
 from ryu.ofproto import ofproto_v1_3 as ofp
 
 
@@ -1860,6 +1861,10 @@ def run_tests():
 
 
 if __name__ == '__main__':
+    if '-c' in sys.argv[1:] or '--clean' in sys.argv[1:]:
+        print 'Cleaning up test interfaces, processes and openvswitch configuration from previous test runs'
+        Cleanup.cleanup()
+        sys.exit(0)
     if not check_dependencies():
         print ('dependency check failed. check required library/binary '
                'list in header of this script')


### PR DESCRIPTION
Mininet likes to leave lots of temporary system configuration lying around if we don't cleanly exit a test run. Add a mode for cleaning this configuration up.