### PR TITLE
Configuration fixes and additions

### DIFF
--- a/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
@@ -90,6 +90,8 @@ def _dp_config_path(config_file, parent_file=None):
 def _dp_parser_v1(conf, config_file, logname):
     logger = get_logger(logname)
 
+    config_path = _dp_config_path(config_file)
+
     # TODO: warn when the configuration contains meaningless elements
     # they are probably typos
     if 'dp_id' not in conf:
@@ -119,8 +121,8 @@ def _dp_parser_v1(conf, config_file, logname):
         logger.exception('Error in config file: %s', err)
         return None
 
-    with open(config_file, 'r') as f:
-        return ({config_file: hashlib.sha256(f.read()).hexdigest()}, [dp])
+    with open(config_path, 'r') as f:
+        return ({config_path: hashlib.sha256(f.read()).hexdigest()}, [dp])
 
 def _dp_include(config_hashes, parent_file, config_file, dps_conf, vlans_conf, acls_conf, logname):
     logger = get_logger(logname)
@@ -181,6 +183,7 @@ def _dp_include(config_hashes, parent_file, config_file, dps_conf, vlans_conf, a
                 config_file, include_path,
                 new_dps_conf, new_vlans_conf, new_acls_conf,
                 logname):
+            new_config_hashes[include_path] = None
             logger.warning('skipping optional include file: %s', include_path)
 
     # Actually update the configuration data structures,

--- a/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
@@ -118,19 +118,19 @@ def _dp_parser_v1(conf, config_file, logname):
 def _dp_include(config_hashes, parent_file, config_file, dps_conf, vlans_conf, acls_conf, logname):
     logger = get_logger(logname)
 
-    config = os.path.join(
+    config_path = os.path.join(
         os.path.dirname(parent_file),
         config_file,
     ) if parent_file and not os.path.isabs(config_file) else config_file
 
-    if not os.path.isfile(config):
-        logger.warning('not a regular file or does not exist: %s', config)
+    if not os.path.isfile(config_path):
+        logger.warning('not a regular file or does not exist: %s', config_path)
         return False
 
-    conf = read_config(config, logname)
+    conf = read_config(config_path, logname)
 
     if not conf:
-        logger.warning('error loading config from file: %s', config)
+        logger.warning('error loading config from file: %s', config_path)
         return False
 
     dps_conf.update(conf.pop('dps', {}))
@@ -138,16 +138,16 @@ def _dp_include(config_hashes, parent_file, config_file, dps_conf, vlans_conf, a
     acls_conf.update(conf.pop('acls', {}))
 
     for include_file in conf.pop('include', []):
-        if not _dp_include(config, include_file, dps_conf, vlans_conf, acls_conf, logname):
+        if not _dp_include(config_hashes, config_path, include_file, dps_conf, vlans_conf, acls_conf, logname):
             logger.error('unable to load required include file: %s', include_file)
             return False
 
     for include_file in conf.pop('include-optional', []):
-        if not _dp_include(config, include_file, dps_conf, vlans_conf, acls_conf, logname):
+        if not _dp_include(config_hashes, config_path, include_file, dps_conf, vlans_conf, acls_conf, logname):
             logger.warning('skipping optional include file: %s', include_file)
 
-    with open(config_file, 'r') as f:
-        config_hashes[config_file] = hashlib.sha256(f.read()).hexdigest()
+    with open(config_path, 'r') as f:
+        config_hashes[config_path] = hashlib.sha256(f.read()).hexdigest()
 
     return True
 

--- a/src/ryu_faucet/org/onfsdn/faucet/faucet.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/faucet.py
@@ -208,10 +208,20 @@ class Faucet(app_manager.RyuApp):
         new_config_file = os.getenv('FAUCET_CONFIG', self.config_file)
         if new_config_file == self.config_file:
             for config_file, config_hash in self.config_hashes.iteritems():
+                # Config file not loaded but exists = reload.
+                if config_hash is None and os.path.isfile(config_file):
+                    changed = True
+                    break
+                # Config file loaded but no longer exists = reload.
+                if config_hash and not os.path.isfile(config_file):
+                    changed = True
+                    break
+                # Config file hash has changed = reload.
                 with open(config_file, 'r') as f:
                     if config_hash != hashlib.sha256(f.read()).hexdigest():
                         changed = True
                         break
+        # FAUCET_CONFIG has changed = reload.
         else:
             self.config_file = new_config_file
             changed = True

--- a/tests/config/testconfigv2-acls.yaml
+++ b/tests/config/testconfigv2-acls.yaml
@@ -1,4 +1,10 @@
 ---
+# The file included below has an include loop.
+# In this case, the parser should skip the below
+# file, and not infinite loop.
+include-optional:
+    - testconfigv2-includeloop.yaml
+
 acls:
     acl1:
         - rule:

--- a/tests/config/testconfigv2-includeloop.yaml
+++ b/tests/config/testconfigv2-includeloop.yaml
@@ -1,0 +1,14 @@
+---
+include:
+- testconfigv2-acls.yaml
+
+acls:
+    acl1:
+        - rule:
+            nw_dst: '192.168.0.0/16'
+            dl_type: 0x800
+            actions:
+                allow: 1
+        - rule:
+            actions:
+                allow: 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -51,10 +51,26 @@ class DistConfigTestCase(unittest.TestCase):
             'config/testgaugeconfig.yaml', logname)
 
     def test_hashes(self):
-        for config_hashes in (self.v1_config_hashes, self.v2_config_hashes):
-            for config_file, config_hash in config_hashes.iteritems():
-                with open(config_file, 'r') as f:
-                    self.assertEquals(config_hash, hashlib.sha256(f.read()).hexdigest())
+        testconfig_yaml = os.path.realpath('config/testconfig.yaml')
+        testconfigv2_yaml = os.path.realpath('config/testconfigv2.yaml')
+        testconfigv2_dps_yaml = os.path.realpath('config/testconfigv2-dps.yaml')
+        testconfigv2_vlans_yaml = os.path.realpath('config/testconfigv2-vlans.yaml')
+        testconfigv2_acls_yaml = os.path.realpath('config/testconfigv2-acls.yaml')
+        testconfigv2_includeloop_yaml = os.path.realpath('config/testconfigv2-includeloop.yaml')
+
+        with open(testconfig_yaml, 'r') as f:
+            self.assertEquals(self.v1_config_hashes[testconfig_yaml], hashlib.sha256(f.read()).hexdigest())
+
+        with open(testconfigv2_yaml, 'r') as f:
+            self.assertEquals(self.v2_config_hashes[testconfigv2_yaml], hashlib.sha256(f.read()).hexdigest())
+        with open(testconfigv2_dps_yaml, 'r') as f:
+            self.assertEquals(self.v2_config_hashes[testconfigv2_dps_yaml], hashlib.sha256(f.read()).hexdigest())
+        with open(testconfigv2_vlans_yaml, 'r') as f:
+            self.assertEquals(self.v2_config_hashes[testconfigv2_vlans_yaml], hashlib.sha256(f.read()).hexdigest())
+        with open(testconfigv2_acls_yaml, 'r') as f:
+            self.assertEquals(self.v2_config_hashes[testconfigv2_acls_yaml], hashlib.sha256(f.read()).hexdigest())
+        # Not loaded due to the include loop.
+        self.assertEquals(self.v2_config_hashes[testconfigv2_includeloop_yaml], None)
 
     def test_dps(self):
         for dp in (self.v1_dp, self.v2_dp):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
 import logging
 import sys
 import os
@@ -38,14 +39,22 @@ class DistConfigTestCase(unittest.TestCase):
             logging.Formatter(log_fmt, '%b %d %H:%M:%S'))
         logger.addHandler(logger_handler)
         logger.propagate = 0
-        logger.setLevel(logging.WARNING)
+        logger.setLevel(logging.CRITICAL)
 
-        self.v1_dp = dp_parser('config/testconfig.yaml', logname)[0]
-        self.v2_dp = dp_parser('config/testconfigv2.yaml', logname)[0]
+        self.v1_config_hashes, self.v1_dps = dp_parser('config/testconfig.yaml', logname)
+        self.v1_dp = self.v1_dps[0]
+        self.v2_config_hashes, self.v2_dps = dp_parser('config/testconfigv2.yaml', logname)
+        self.v2_dp = self.v2_dps[0]
         self.v1_watchers = watcher_parser(
             'config/testgaugeconfig.conf', logname)
         self.v2_watchers = watcher_parser(
             'config/testgaugeconfig.yaml', logname)
+
+    def test_hashes(self):
+        for config_hashes in (self.v1_config_hashes, self.v2_config_hashes):
+            for config_file, config_hash in config_hashes.iteritems():
+                with open(config_file, 'r') as f:
+                    self.assertEquals(config_hash, hashlib.sha256(f.read()).hexdigest())
 
     def test_dps(self):
         for dp in (self.v1_dp, self.v2_dp):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,7 +70,7 @@ class DistConfigTestCase(unittest.TestCase):
         with open(testconfigv2_acls_yaml, 'r') as f:
             self.assertEquals(self.v2_config_hashes[testconfigv2_acls_yaml], hashlib.sha256(f.read()).hexdigest())
         # Not loaded due to the include loop.
-        self.assertEquals(self.v2_config_hashes[testconfigv2_includeloop_yaml], None)
+        self.assertIsNone(self.v2_config_hashes[testconfigv2_includeloop_yaml])
 
     def test_dps(self):
         for dp in (self.v1_dp, self.v2_dp):


### PR DESCRIPTION
Some improvements to configuration file handling.

* Fixes an infinite loop situation where include files could be recursively loaded, by keeping track of open files and logging an error (`include`) or skipping the file (`include-optional`) if an include file loop is found.

* Only commits changes an include file makes to the configuration if it was successfully loaded, by storing changes in a data structure until the end of `_dp_include()`, after all checks are done.

* Only reloads the Faucet configuration upon `SIGHUP` if changes to the configuration were found in some way. It does this when one of the following conditions are met:
  * The `FAUCET_CONFIG` environment variable has changed
  * An include file that was not loaded now exists
  * A file that has been loaded no longer exists
  * Loaded files have been changed, by comparing a SHA256 hash of the currently loaded file with the hash of the file that exists on the file system

* Adds tests to `test_config.py` to take into account the above changes.