### PR TITLE
Move all tests to use v2 config format, and log a warning when parsin…

### DIFF
--- a/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
@@ -49,6 +49,8 @@ def dp_parser(config_file, logname):
     version = conf.pop('version', 1)
 
     if version == 1:
+        logger.warning(
+            'Version 1 config is UNSUPPORTED. Please move to version 2')
         return _dp_parser_v1(conf, config_file, logname)
     elif version == 2:
         return _dp_parser_v2(conf, config_file, logname)


### PR DESCRIPTION
…g v1 (v1 unsupported).