### PR TITLE
Incrementally reload faucet config

### DIFF
--- a/src/ryu_faucet/org/onfsdn/faucet/dp.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/dp.py
@@ -16,6 +16,7 @@
 from conf import Conf
 from vlan import VLAN
 from port import Port
+from valve_acl import ACL
 
 import networkx
 
@@ -132,7 +133,7 @@ class DP(Conf):
 
     def add_acl(self, acl_ident, acl_conf=None):
         if acl_conf is not None:
-            self.acls[acl_ident] = [x['rule'] for x in acl_conf]
+            self.acls[acl_ident] = ACL(acl_ident, acl_conf)
 
     def add_port(self, port):
         port_num = port.number
@@ -271,7 +272,7 @@ class DP(Conf):
 
         def resolve_port_names_in_acls():
             for acl in self.acls.itervalues():
-                for rule_conf in acl:
+                for rule_conf in acl.rules:
                     for attrib, attrib_value in rule_conf.iteritems():
                         if attrib == 'actions':
                             if 'mirror' in attrib_value:

--- a/src/ryu_faucet/org/onfsdn/faucet/port.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/port.py
@@ -50,7 +50,7 @@ class Port(Conf):
         self._id = _id
         self.update(conf)
         self.set_defaults()
-        self.phys_up = False
+        self.dyn_phys_up = False
 
     def set_defaults(self):
         for key, value in self.defaults.iteritems():
@@ -60,6 +60,14 @@ class Port(Conf):
         self._set_default('description', self.name)
         self._set_default('tagged_vlans', [])
 
+    @property
+    def phys_up(self):
+        return self.dyn_phys_up
+
+    @phys_up.setter
+    def phys_up(self, status):
+        self.dyn_phys_up = status
+
     def running(self):
         return self.enabled and self.phys_up
 
@@ -67,10 +75,14 @@ class Port(Conf):
         return hash(self) == hash(other)
 
     def __hash__(self):
-        return hash(('Port', self.number))
+        items = [(k,v) for k, v in self.__dict__.iteritems() if 'dyn' not in k]
+        return hash(frozenset(map(str, items)))
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
     def __str__(self):
         return self.name
+
+    def __repr__(self):
+        return "Port %s" % self.number

--- a/src/ryu_faucet/org/onfsdn/faucet/valve_acl.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/valve_acl.py
@@ -16,6 +16,21 @@
 
 import valve_of
 
+class ACL(object):
+
+    def __init__(self, id_, rule_conf):
+
+        self._id = id_
+        self.rules = [x['rule'] for x in rule_conf]
+
+    def __hash__(self):
+        return hash(frozenset(map(str, self.__dict__.iteritems())))
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 def build_acl_entry(rule_conf, acl_allow_inst, port_num):
     acl_inst = []

--- a/src/ryu_faucet/org/onfsdn/faucet/vlan.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/vlan.py
@@ -23,11 +23,6 @@ class VLAN(Conf):
     untagged = None
     vid = None
     controller_ips = None
-    ipv4_routes = None
-    ipv6_routes = None
-    arp_cache = None
-    nd_cache = None
-    host_cache = None
     bgp_as = None
     bgp_port = None
     bgp_routerid = None
@@ -37,6 +32,14 @@ class VLAN(Conf):
     bgp_neighbour_as = None
     routes = None
     max_hosts = None
+    unicast_flood = None
+    # Define dynamic variables with prefix dyn_ to distinguish from variables set
+    # configuration
+    dyn_ipv4_routes = None
+    dyn_ipv6_routes = None
+    dyn_arp_cache = None
+    dyn_nd_cache = None
+    dyn_host_cache = None
 
     defaults = {
         'name': None,
@@ -65,11 +68,11 @@ class VLAN(Conf):
         self._id = _id
         self.tagged = []
         self.untagged = []
-        self.ipv4_routes = {}
-        self.ipv6_routes = {}
-        self.arp_cache = {}
-        self.nd_cache = {}
-        self.host_cache = {}
+        self.dyn_ipv4_routes = {}
+        self.dyn_ipv6_routes = {}
+        self.dyn_arp_cache = {}
+        self.dyn_nd_cache = {}
+        self.dyn_host_cache = {}
 
         if self.controller_ips:
             self.controller_ips = [
@@ -91,6 +94,46 @@ class VLAN(Conf):
                     self.ipv4_routes[ip_dst] = ip_gw
                 else:
                     self.ipv6_routes[ip_dst] = ip_gw
+
+    @property
+    def ipv4_routes(self):
+        return self.dyn_ipv4_routes
+
+    @ipv4_routes.setter
+    def ipv4_routes(self, value):
+        self.dyn_ipv4_routes = value
+
+    @property
+    def ipv6_routes(self):
+        return self.dyn_ipv6_routes
+
+    @ipv6_routes.setter
+    def ipv6_routes(self, value):
+        self.dyn_ipv6_routes = value
+
+    @property
+    def arp_cache(self):
+        return self.dyn_arp_cache
+
+    @arp_cache.setter
+    def arp_cache(self, value):
+        self.dyn_arp_cache = value
+
+    @property
+    def nd_cache(self):
+        return self.dyn_nd_cache
+
+    @nd_cache.setter
+    def nd_cache(self, value):
+        self.dyn_nd_cache = value
+
+    @property
+    def host_cache(self):
+        return self.dyn_host_cache
+
+    @host_cache.setter
+    def host_cache(self, value):
+        self.dyn_host_cache = value
 
     def set_defaults(self):
         for key, value in self.defaults.iteritems():
@@ -149,3 +192,13 @@ class VLAN(Conf):
             if ip in controller_ip:
                 return True
         return False
+
+    def __hash__(self):
+        items = [(k,v) for k,v in self.__dict__.iteritems() if 'dyn' not in k]
+        return hash(frozenset(map(str, items)))
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)


### PR DESCRIPTION
incrementally reloading Faucet configs
Detects what changes have been made and reload only what affected by the changes.
Following changes are detectable: 
- port configs change such as native_vlan, unicast_flood, acl_in....
- ACL changes
- VLAN changes: controller_ips....