### PR TITLE
Valve Unittests

### DIFF
--- a/tests/fakeoftable.py
+++ b/tests/fakeoftable.py
@@ -1,0 +1,364 @@
+# Copyright (C) 2015 Research and Innovation Advanced Network New Zealand Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import struct
+from bitstring import Bits
+from ryu.ofproto import ofproto_v1_3 as ofp
+from ryu.ofproto import ofproto_v1_3_parser as parser
+from ryu.lib import addrconv
+
+class FakeOFTable():
+    """Fake OFTable is a virtual openflow pipeline used for testing openflow controllers.
+
+    The tables are populated using apply_ofmsgs and can be queried with
+    is_ouput.
+    """
+
+    def __init__(self, num_tables):
+        self.tables = []
+        for i in range(0, num_tables):
+            self.tables.append([])
+
+    def apply_ofmsgs(self, ofmsgs):
+        """This is used to update the fake flowtable.
+
+        Adds, Deletes and modifies are applied according to section 6.4 of the
+        OpenFlow 1.3 specification."""
+        for ofmsg in ofmsgs:
+            if isinstance(ofmsg, parser.OFPFlowMod):
+                table_id = ofmsg.table_id
+                if table_id == ofp.OFPTT_ALL:
+                    tables = self.tables
+                else:
+                    tables = [self.tables[table_id]]
+                new_fte = FlowTableEntry(ofmsg)
+                for table in tables:
+                    if ofmsg.command == ofp.OFPFC_ADD:
+                        # From the 1.3 spec, section 6.4:
+                        # For add requests (OFPFC_ADD) with the
+                        # OFPFF_CHECK_OVERLAP flag set, the switch must first
+                        # check for any overlapping flow entries in the
+                        # requested table.  Two flow entries overlap if a
+                        # single packet may match both, and both flow entries
+                        # have the same priority, but the two flow entries
+                        # don't have the exact same match.  If an overlap
+                        # conflict exists between an existing flow entry and
+                        # the add request, the switch must refuse the addition
+                        # and respond with an ofp_error_msg with
+                        # OFPET_FLOW_MOD_FAILED type and OFPFMFC_OVERLAP code.
+                        #
+                        # Without the check overlap flag it seems like it is
+                        # possible that we can have overlapping flow table
+                        # entries which will cause ambiguous behaviour. This is
+                        # obviously unnacceptable so we will assume this is
+                        # always set
+                        add = True
+                        for old_fte in table:
+                            if new_fte.fte_matches(old_fte, strict=True):
+                                table.remove(old_fte)
+                                break
+                            elif new_fte.overlaps(old_fte):
+                                add = False
+                                break
+                        if add:
+                            table.append(new_fte)
+                    elif ofmsg.command == ofp.OFPFC_DELETE:
+                        removals = []
+                        for old_fte in table:
+                            if new_fte.fte_matches(old_fte):
+                                removals.append(old_fte)
+                        for old_fte in removals:
+                            table.remove(old_fte)
+                    elif ofmsg.command == ofp.OFPFC_DELETE_STRICT:
+                        for old_fte in table:
+                            if new_fte.fte_matches(old_fte, strict=True):
+                                table.remove(old_fte)
+                                break
+                    elif ofmsg.command == ofp.OFPFC_MODIFY:
+                        for old_fte in table:
+                            if new_fte.fte_matches(old_fte):
+                                old_fte.instructions = new_fte.instructions
+                    elif ofmsg.command == ofp.OFPFC_MODIFY_STRICT:
+                        for old_fte in table:
+                            if new_fte.fte_matches(old_fte, strict=True):
+                                old_fte.instructions = new_fte.instructions
+                                break
+        self.sort_tables()
+
+    def lookup(self, match):
+        """Return the entries from flowmods that matches match.
+
+        Searches each table in the pipeline for the entries that will be
+        applied to the packet with fields represented by match.
+
+        Arguments:
+        match: a dictionary keyed by header field names with values.
+                header fields not provided in match must be wildcarded for the
+                entry to be considered matching.
+
+        Returns: a list of the flowmods that will be applied to the packet
+                represented by match
+        """
+        packet_dict = match.copy() # Packet headers may be modified
+        instructions = []
+        table_id = 0
+        goto_table = True
+        while goto_table:
+            goto_table = False
+            table = self.tables[table_id]
+            matching_fte = None
+            # find a matching flowmod
+            for fte in table:
+                if fte.pkt_matches(packet_dict):
+                    matching_fte = fte
+                    break
+            # if a flowmod is found, make modifications to the match values and
+            # determine if another lookup is necessary
+            if matching_fte:
+                for instruction in matching_fte.instructions:
+                    instructions.append(instruction)
+                    if instruction.type == ofp.OFPIT_GOTO_TABLE:
+                        if table_id < instruction.table_id:
+                            table_id = instruction.table_id
+                            goto_table = True
+                    elif instruction.type == ofp.OFPIT_APPLY_ACTIONS:
+                        for action in instruction.actions:
+                            if action.type == ofp.OFPAT_SET_FIELD:
+                                packet_dict[action.key] = action.value
+        return instructions
+
+    def is_output(self, match, port=None, vid=None):
+        """Return true if packets with match fields is output to port with
+        correct vlan.
+
+        If port is none it will return true if output to any port (including
+        special ports) regardless of vlan tag.
+
+        If vid is none it will return true if output to specified port
+        regardless of vlan tag.
+
+        To specify the packet should be output without a vlan tag set the
+        OFPVID_PRESENT bit in vid is 0.
+
+        Will raise IndexError if a vlan is specified and the packet is output
+        without a vlan tag.
+
+        Arguments:
+        Match: a dictionary keyed by header field names with values.
+        """
+        # vid_stack represents the packet's vlan stack, innermost label listed
+        # first
+        match_vid = match.get('vlan_vid', 0)
+        if match_vid & ofp.OFPVID_PRESENT != 0:
+            vid_stack = [match_vid]
+        else:
+            vid_stack = []
+
+        instructions = self.lookup(match)
+
+        for instruction in instructions:
+            if instruction.type == ofp.OFPIT_APPLY_ACTIONS:
+                for action in instruction.actions:
+
+                    if action.type == ofp.OFPAT_PUSH_VLAN:
+                        vid_stack.append(ofp.OFPVID_PRESENT)
+
+                    elif action.type == ofp.OFPAT_POP_VLAN:
+                        vid_stack.pop()
+
+                    elif action.type == ofp.OFPAT_SET_FIELD:
+                        if action.key == 'vlan_vid':
+                            vid_stack[-1] = action.value
+                        else:
+                            continue
+
+                    elif action.type == ofp.OFPAT_OUTPUT:
+                        if port is None:
+                            return True
+
+                        elif action.port == port:
+
+                            if vid is None:
+                                return True
+
+                            elif vid & ofp.OFPVID_PRESENT == 0:
+                                return len(vid_stack) == 0
+
+                            else:
+                                return vid == vid_stack[-1]
+
+        return False
+
+    def __str__(self):
+        string = ""
+        for table_id, table in enumerate(self.tables):
+            string += "----- Table {0} -----\n".format(table_id)
+            for flowmod in table:
+                string += str(flowmod)
+                string += "\n"
+        return string
+
+    def sort_tables(self):
+        for table_id, table in enumerate(self.tables):
+            self.tables[table_id] = sorted(
+                table,
+                key=lambda x: x.priority,
+                reverse=True)
+        return self.tables
+
+    def parse_of_match(self, match):
+        values_dict = {}
+        masks_dict = {}
+
+        return (values_dict, masks_dict)
+
+class FlowTableEntry(object):
+
+    MAC_MATCH_FIELDS = (
+        'eth_src', 'eth_dst', 'arp_sha', 'arp_tha', 'ipv6_nd_sll',
+        'ipv6_nd_tll'
+        )
+    IPV4_MATCH_FIELDS = ('ipv4_src', 'ipv4_dst', 'arp_spa', 'arp_tpa')
+    IPV6_MATCH_FIELDS = ('ipv6_src', 'ipv6_dst', 'ipv6_nd_target')
+
+    def __init__(self, flowmod):
+        self.priority = flowmod.priority
+        self.instructions = flowmod.instructions
+        self.match_values = {}
+        self.match_masks = {}
+        self.out_port = None
+        if (flowmod.command == ofp.OFPFC_DELETE or\
+           flowmod.command == ofp.OFPFC_DELETE_STRICT) and\
+           flowmod.out_port != ofp.OFPP_ANY:
+            self.out_port = flowmod.out_port
+
+        for key, v in flowmod.match.iteritems():
+            if isinstance(v, tuple):
+                val, mask = v
+            else:
+                val = v
+                mask = -1
+
+            mask = self.match_to_bits(key, mask)
+            val = self.match_to_bits(key, val) & mask
+            self.match_values[key] = val
+            self.match_masks[key] = mask
+
+    def out_port_matches(self, other):
+        if self.out_port is None or self.out_port == ofp.OFPP_ANY:
+            return True
+        for instruction in other.instructions:
+            if instruction.type == ofp.OFPIT_APPLY_ACTIONS:
+                for action in instruction.actions:
+                    if action.type == ofp.OFPAT_OUTPUT:
+                        if action.port == self.out_port:
+                            return True
+        return False
+
+    def pkt_matches(self, pkt_dict):
+        '''returns True if pkt_dict matches this flow table entry.
+
+        args:
+            pkt_dict - a dictionary keyed by flow table match fields with
+                values
+        if an element is included in the flow table entry match fields but not
+        in the pkt_dict that is assumed to indicate a failed match'''
+        #TODO: add cookie and out_group
+        for key, val in self.match_values.iteritems():
+            if key not in pkt_dict:
+                return False
+            else:
+                val_bits = self.match_to_bits(key, pkt_dict[key])
+                if val_bits != (val & self.match_masks[key]):
+                    return False
+        return True
+
+    def fte_matches(self, other, strict=False):
+        if not self.out_port_matches(other):
+            return False
+        if strict:
+            return self.priority == other.priority and\
+                   self.match_values == other.match_values and\
+                   self.match_masks == other.match_masks
+        else:
+            for key, val in self.match_values.iteritems():
+                if key not in other.match_values:
+                    return False
+                else:
+                    if other.match_values[key] & self.match_masks[key] != val:
+                        return False
+        return True
+
+
+    def overlaps(self, other):
+        ''' returns True if any packet can match both self and other.'''
+        # This is different from the matches method as matches assumes an
+        # undefined field is a failed match. In this case an undefined field is
+        # potentially an overlap and therefore is considered success
+        if other.priority != self.priority:
+            return False
+        for k, v in self.match_values.iteritems():
+            if k in other.match_values:
+                if v & other.match_masks[k] != other.match_values[k]:
+                    return False
+                if other.match_values[k] & self.match_masks[k] != v:
+                    return False
+        return True
+
+    def match_to_bits(self, key, val):
+        if isinstance(val, Bits):
+            return val
+
+        if key in self.MAC_MATCH_FIELDS:
+            if val is -1:
+                val = Bits(int=-1, length=48)
+            elif isinstance(val, str):
+                val = Bits(bytes=addrconv.mac.text_to_bin(val), length=48)
+
+        elif key in self.IPV4_MATCH_FIELDS:
+            if val is -1:
+                val = Bits(int=-1, length=32)
+            elif isinstance(val, str):
+                val = Bits(bytes=addrconv.mac.text_to_bin(val), length=32)
+
+        elif key in self.IPV6_MATCH_FIELDS:
+            if val is -1:
+                val = Bits(int=-1, length=128)
+            elif isinstance(val, str):
+                val = Bits(bytes=addrconv.ipv6.text_to_bin(val), length=128)
+
+        else:
+            val = Bits(int=int(val), length=64)
+
+        return val
+
+    def __lt__(self, other):
+        return self.priority < other.priority
+
+    def __eq__(self, other):
+        return self.priority == other.priority and\
+               self.match_values == other.match_values and\
+               self.match_masks == other.match_masks and\
+               self.out_port == other.out_port and\
+               self.instructions == other.instructions
+
+    def __str__(self):
+        string = 'priority: {0}'.format(self.priority)
+        for key, val in self.match_values.iteritems():
+            mask = self.match_masks[key]
+            string += ' {0}: {1}'.format(key, val)
+            if mask.int != -1:
+                string += '/{0}'.format(mask)
+        string += ' Instructions: {0}'.format(str(self.instructions))
+        return string

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -1,0 +1,556 @@
+#!/usr/bin/python
+
+# Copyright (C) 2015 Research and Innovation Advanced Network New Zealand Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import os
+import unittest
+import tempfile
+import shutil
+from fakeoftable import FakeOFTable
+
+testdir = os.path.dirname(__file__)
+srcdir = '../src/ryu_faucet/org/onfsdn/'
+sys.path.insert(0, os.path.abspath(os.path.join(testdir, srcdir)))
+
+from ryu.ofproto import ether
+from ryu.ofproto import ofproto_v1_3 as ofp
+from ryu.lib.packet import ethernet, arp, vlan, ipv4, ipv6, packet
+from faucet.valve import valve_factory
+from faucet.config_parser import dp_parser
+
+def build_pkt(pkt):
+    layers = []
+    if 'arp_target_ip' in pkt:
+        ethertype = 0x806
+        layers.append(arp.arp(dst_ip=pkt['arp_target_ip']))
+    elif 'ipv6_src' in pkt:
+        ethertype = 0x86DD
+        layers.append(ipv6.ipv6(src=pkt['ipv6_src'], dst=pkt['ipv6_src']))
+    else:
+        ethertype = 0x800
+        if 'ipv4_src' in pkt:
+            net = ipv4.ipv4(src=pkt['ipv4_src'], dst=pkt['ipv4_dst'])
+        else:
+            net = ipv4.ipv4()
+        layers.append(net)
+    if 'vid' in pkt:
+        tpid = 0x8100
+        layers.append(vlan.vlan(vid=pkt['vid'], ethertype=ethertype))
+    else:
+        tpid = ethertype
+    eth = ethernet.ethernet(
+        dst=pkt['eth_dst'],
+        src=pkt['eth_src'],
+        ethertype=tpid)
+    layers.append(eth)
+    result = packet.Packet()
+    for layer in layers:
+        result.add_protocol(layer)
+    return result
+
+
+class ValveTestCase(unittest.TestCase):
+    CONFIG = """
+version: 2
+dps:
+    s1:
+        ignore_learn_ins: 0
+        hardware: 'Open vSwitch'
+        dp_id: 1
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: v100
+            p2:
+                number: 2
+                native_vlan: v200
+                tagged_vlans: [v100]
+            p3:
+                number: 3
+                tagged_vlans: [v100, v200]
+            p4:
+                number: 4
+                tagged_vlans: [v200]
+            p5:
+                number: 5
+vlans:
+    v100:
+        vid: 100
+    v200:
+        vid: 200
+"""
+    DP_ID = 1
+    NUM_PORTS = 5
+    P1_V100_MAC = '00:00:00:01:00:01'
+    P2_V200_MAC = '00:00:00:02:00:02'
+    P3_V200_MAC = '00:00:00:02:00:03'
+    UNKNOWN_MAC = '00:00:00:04:00:04'
+    V100 = 100|ofp.OFPVID_PRESENT
+    V200 = 200|ofp.OFPVID_PRESENT
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.config_file = os.path.join(self.tmpdir, 'valve_unit.yaml')
+        self.table = FakeOFTable(7)
+        with open(self.config_file, 'w') as f:
+            f.write(self.CONFIG)
+        _, dps = dp_parser(self.config_file, 'test_valve')
+        self.valve = valve_factory(dps[0])(dps[0], 'test_valve')
+
+        # establish connection to datapath
+        ofmsgs = self.valve.datapath_connect(
+            self.DP_ID,
+            range(1, self.NUM_PORTS + 1)
+            )
+        self.table.apply_ofmsgs(ofmsgs)
+
+        # learn some mac addresses
+        self.rcv_packet(1, 100, {
+            'eth_src': self.P1_V100_MAC,
+            'eth_dst': self.UNKNOWN_MAC
+            })
+        self.rcv_packet(2, 200, {
+            'eth_src': self.P2_V200_MAC,
+            'eth_dst': self.P3_V200_MAC,
+            'vid': 200
+            })
+        self.rcv_packet(3, 200, {
+            'eth_src': self.P3_V200_MAC,
+            'eth_dst': self.P2_V200_MAC,
+            'vid': 200
+            })
+
+    def rcv_packet(self, port, vid, match):
+        pkt = build_pkt(match)
+        rcv_packet_ofmsgs = self.valve.rcv_packet(
+            dp_id=1,
+            valves={},
+            in_port=port,
+            vlan_vid=vid,
+            pkt=pkt
+            )
+        self.table.apply_ofmsgs(rcv_packet_ofmsgs)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_invalid_vlan(self):
+        """Test that packets with incorrect vlan tagging get dropped."""
+
+        matches = [
+            {'in_port': 1, 'vlan_vid': 18|ofp.OFPVID_PRESENT},
+            {'in_port': 1, 'vlan_vid': self.V100},
+            {'in_port': 3, 'vlan_vid': 0}
+            ]
+        for match in matches:
+            self.assertFalse(
+                self.table.is_output(match),
+                msg="Packets with incorrect vlan tags are output")
+
+    def test_acl(self):
+        pass
+
+    def test_unknown_eth_src(self):
+        """Test that packets from unknown macs are sent to controller.
+
+        Untagged packets should have VLAN tags pushed before they are sent to
+        the controler.
+        """
+        matches = [
+            {'in_port': 1, 'vlan_vid': 0},
+            {'in_port': 1, 'vlan_vid': 0, 'eth_src' : self.UNKNOWN_MAC},
+            {
+                'in_port': 1,
+                'vlan_vid': 0,
+                'eth_src' : self.P2_V200_MAC
+                },
+            {'in_port': 2, 'vlan_vid': 0, 'eth_dst' : self.UNKNOWN_MAC},
+            {'in_port': 2, 'vlan_vid': 0},
+            {
+                'in_port': 2,
+                'vlan_vid': self.V100,
+                'eth_src' : self.P2_V200_MAC
+                },
+            {
+                'in_port': 2,
+                'vlan_vid': self.V100,
+                'eth_src' : self.UNKNOWN_MAC,
+                'eth_dst' : self.P1_V100_MAC
+                },
+            ]
+        for match in matches:
+            if match['vlan_vid'] != 0:
+                vid = match['vlan_vid']
+            else:
+                vid = self.valve.dp.get_native_vlan(match['in_port']).vid
+                vid = vid|ofp.OFPVID_PRESENT
+            self.assertTrue(
+                self.table.is_output(match, ofp.OFPP_CONTROLLER, vid=vid),
+                msg="Packet with unknown ethernet src not sent to controller: "
+                "{0}".format(match))
+
+    def test_unknown_eth_dst_rule(self):
+        """Test that packets with unkown eth dst addrs get flooded correctly.
+
+        They must be output to each port on the associated vlan, with the
+        correct vlan tagging. And they must not be forwarded to a port not
+        on the associated vlan"""
+        matches = [
+            {
+                'in_port': 3,
+                'vlan_vid': self.V100,
+                },
+            {
+                'in_port': 2,
+                'vlan_vid': 0,
+                'eth_dst': self.P1_V100_MAC
+                },
+            {'in_port': 1, 'vlan_vid': 0, 'eth_src': self.P1_V100_MAC},
+            {
+                'in_port': 3,
+                'vlan_vid': self.V200,
+                'eth_dst': self.P1_V100_MAC
+                },
+            ]
+        dp = self.valve.dp
+        for match in matches:
+            in_port = match['in_port']
+
+            if 'vlan_vid' in match and\
+               match['vlan_vid'] & ofp.OFPVID_PRESENT is not 0:
+                valve_vlan = dp.vlans[match['vlan_vid'] & ~ofp.OFPVID_PRESENT]
+            else:
+                valve_vlan = self.valve.dp.get_native_vlan(in_port)
+
+            remaining_ports = set(range(1, 6))
+
+            # Check packets are output to each port on vlan
+            for p in valve_vlan.get_ports():
+                remaining_ports.discard(p.number)
+                if p.number != in_port and p.running():
+                    if valve_vlan.port_is_tagged(p.number):
+                        vid = valve_vlan.vid|ofp.OFPVID_PRESENT
+                    else:
+                        vid = 0
+                    self.assertTrue(
+                        self.table.is_output(match, port=p.number, vid=vid),
+                        msg="packet with unknown eth dst ({0}) not output "
+                            "correctly on vlan {1} to port {2}".format(
+                                match, valve_vlan.vid, p.number)
+                        )
+
+            # Check packets are not output to ports not on vlan
+            for p in remaining_ports:
+                self.assertFalse(
+                    self.table.is_output(match, port=p),
+                    msg="packet with unkown eth dst output to port not on its"
+                    " vlan ({0})".format(p))
+
+    def test_known_eth_src_rule(self):
+        """test that packets with known eth src addrs are not sent to controller."""
+        matches = [
+            {
+                'in_port': 1,
+                'vlan_vid': 0,
+                'eth_src': self.P1_V100_MAC
+                },
+            {
+                'in_port': 2,
+                'vlan_vid': self.V200,
+                'eth_src': self.P2_V200_MAC
+                },
+            {
+                'in_port': 3,
+                'vlan_vid': self.V200,
+                'eth_src': self.P3_V200_MAC,
+                'eth_dst': self.P2_V200_MAC
+                }
+            ]
+        for match in matches:
+            self.assertFalse(
+                self.table.is_output(match, port=ofp.OFPP_CONTROLLER),
+                msg="Packet ({0}) output to controller when eth_src address"
+                    " is known".format(match))
+
+
+    def test_known_eth_src_deletion(self):
+        """Verify that when a mac changes port the old rules get deleted.
+
+        If a mac address is seen on one port, then seen on a different port on
+        the same vlan the rules associated with that mac address on previous
+        port need to be deleted. IE packets with that mac address arriving on
+        the old port should be output to the controller."""
+
+        self.rcv_packet(3, 200, {
+            'eth_src': self.P2_V200_MAC,
+            'eth_dst': self.UNKNOWN_MAC,
+            'vlan_vid': 200
+            })
+
+        match = {
+            'in_port': 2,
+            'vlan_vid': 0,
+            'eth_src': self.P2_V200_MAC
+            }
+        self.assertTrue(
+            self.table.is_output(match, port=ofp.OFPP_CONTROLLER),
+            msg='eth src rule not deleted when mac seen on another port')
+
+    def test_known_eth_dst_rule(self):
+        """Test that packets with known eth dst addrs are output correctly.
+
+        Output to the correct port with the correct vlan tagging."""
+        match_results = [
+            ({
+                'in_port': 2,
+                'vlan_vid': self.V100,
+                'eth_dst': self.P1_V100_MAC
+                }, {
+                'out_port': 1,
+                'vlan_vid': 0
+                }),
+            ({
+                'in_port': 3,
+                'vlan_vid': self.V200,
+                'eth_dst': self.P2_V200_MAC,
+                'eth_src': self.P3_V200_MAC
+                }, {
+                'out_port': 2,
+                'vlan_vid': 0,
+                })
+            ]
+        for match, result in match_results:
+            self.assertTrue(
+                self.table.is_output(
+                    match, result['out_port'], vid=result['vlan_vid']),
+                msg="packet not output to port correctly when eth dst is known")
+            incorrect_ports = range(1, self.NUM_PORTS + 1)
+            incorrect_ports.remove(result['out_port'])
+            for port in incorrect_ports:
+                self.assertFalse(
+                    self.table.is_output(match, port=port),
+                    msg="packet: {0} output to incorrect port ({1}) when eth "
+                    "dst is known".format(match, port))
+
+    def test_mac_learning_vlan_separation(self):
+        """Test that when a mac is seen on a second vlan the original vlan
+        rules are unaffected."""
+        self.rcv_packet(2, 200, {
+            'eth_src': self.P1_V100_MAC,
+            'eth_dst': self.UNKNOWN_MAC,
+            'vlan_vid': 200
+            })
+
+        # check eth_src rule
+        match1 = {
+            'in_port': 1,
+            'vlan_vid': 0,
+            'eth_src': self.P1_V100_MAC
+            }
+        self.assertFalse(
+            self.table.is_output(match1, ofp.OFPP_CONTROLLER),
+            msg="mac address being seen on a vlan affects eth_src rule on"
+            " other vlan")
+
+        # check eth_dst rule
+        match2 = {
+            'in_port': 3,
+            'vlan_vid': self.V100,
+            'eth_dst': self.P1_V100_MAC
+            }
+        self.assertTrue(
+            self.table.is_output(match2, port=1, vid=0),
+            msg="mac address being seen on a vlan affects eth_dst rule on "
+            "other vlan")
+        for port in (2, 4):
+            self.assertFalse(
+                self.table.is_output(match2, port=port),
+                msg="mac address being seen on a vlan affects eth_dst rule on "
+                "other vlan")
+
+    def test_known_eth_dst_rule_deletion(self):
+        """Test that eth dst rules are deleted when the mac is learned on
+        another port.
+
+        This should only occur when the mac is seen on the same vlan."""
+        self.rcv_packet(2, 100, {
+            'eth_src': self.P1_V100_MAC,
+            'eth_dst': self.UNKNOWN_MAC
+            })
+        match = {
+            'in_port': 3,
+            'vlan_vid': self.V100,
+            'eth_dst': self.P1_V100_MAC}
+        self.assertTrue(
+            self.table.is_output(match, port=2, vid=self.V100),
+            msg="Packet not output correctly after mac is learnt on new port")
+        self.assertFalse(
+            self.table.is_output(match, port=1),
+            msg="Packet output on old port after mac is learnt on new port")
+
+    def test_port_delete_eth_dst_removal(self):
+        """Test that when a port is disabled packets are correctly output. """
+        match = {
+            'in_port': 2,
+            'vlan_vid': self.V100,
+            'eth_dst': self.P1_V100_MAC}
+
+        vlan = self.valve.dp.vlans[match['vlan_vid'] & ~ofp.OFPVID_PRESENT]
+
+        ofmsgs = self.valve.port_delete(dp_id=self.DP_ID, port_num=1)
+        self.table.apply_ofmsgs(ofmsgs)
+
+        # Check packets are output to each port on vlan
+        for p in vlan.get_ports():
+            if p.number != match['in_port'] and p.running():
+                if vlan.port_is_tagged(p.number):
+                    vid = vlan.vid|ofp.OFPVID_PRESENT
+                else:
+                    vid = 0
+                self.assertTrue(
+                    self.table.is_output(match, port=p.number, vid=vid),
+                    msg="packet ({0}) with eth dst learnt on deleted port not output "
+                        "correctly on vlan {1} to port {2}".format(match, vlan.vid, p.number))
+
+    def test_port_down_eth_src_removal(self):
+        '''Test that when a port goes down and comes back up learnt mac
+        addresses are deleted.'''
+        match = {
+            'in_port': 1,
+            'vlan_vid': 0,
+            'eth_src': self.P1_V100_MAC
+            }
+
+        ofmsgs = self.valve.port_delete(dp_id=self.DP_ID, port_num=1)
+        self.table.apply_ofmsgs(ofmsgs)
+
+        ofmsgs = self.valve.port_add(dp_id=self.DP_ID, port_num=1)
+        self.table.apply_ofmsgs(ofmsgs)
+
+        self.assertTrue(
+            self.table.is_output(match, port=ofp.OFPP_CONTROLLER),
+            msg="Packet not output to controller after port bounce")
+
+    def test_port_add_input(self):
+        """test that when a port is enabled packets are input correctly."""
+        match = {
+            'in_port': 1,
+            'vlan_vid': 0,
+            }
+
+        ofmsgs = self.valve.port_delete(dp_id=self.DP_ID, port_num=1)
+        self.table.apply_ofmsgs(ofmsgs)
+
+        self.assertFalse(
+            self.table.is_output(match, port=2, vid=self.V100),
+            msg="Packet output after port delete")
+
+        ofmsgs = self.valve.port_add(dp_id=self.DP_ID, port_num=1)
+        self.table.apply_ofmsgs(ofmsgs)
+
+        self.assertTrue(
+            self.table.is_output(match, port=2, vid=self.V100),
+            msg="Packet not output after port add")
+
+class ValveReloadConfigTestCase(ValveTestCase):
+    '''Repeats the tests after a config reload'''
+
+    OLD_CONFIG = """
+version: 2
+dps:
+    s1:
+        ignore_learn_ins: 0
+        hardware: 'Open vSwitch'
+        dp_id: 1
+        interfaces:
+            p1:
+                number: 1
+                tagged_vlans: [v100, v200]
+            p2:
+                number: 2
+                native_vlan: v100
+            p3:
+                number: 3
+                tagged_vlans: [v100, v200]
+            p4:
+                number: 4
+                tagged_vlans: [v200]
+            p5:
+                number: 5
+vlans:
+    v100:
+        vid: 100
+    v200:
+        vid: 200
+"""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.config_file = os.path.join(self.tmpdir, 'valve_reload_unit.yaml')
+        self.table = FakeOFTable(7)
+        with open(self.config_file, 'w') as f:
+            f.write(self.OLD_CONFIG)
+        _, dps = dp_parser(self.config_file, 'test_valve')
+        self.valve = valve_factory(dps[0])(dps[0], 'test_valve')
+
+        # establish connection to datapath
+        ofmsgs = self.valve.datapath_connect(
+            self.DP_ID,
+            range(1, self.NUM_PORTS + 1)
+            )
+        self.table.apply_ofmsgs(ofmsgs)
+
+        # learn some mac addresses
+        self.rcv_packet(1, 100, {
+            'eth_src': self.P1_V100_MAC,
+            'eth_dst': self.UNKNOWN_MAC
+            })
+        self.rcv_packet(2, 100, {
+            'eth_src': self.P2_V200_MAC,
+            'eth_dst': self.P3_V200_MAC,
+            'vid': 200
+            })
+        self.rcv_packet(3, 100, {
+            'eth_src': self.P3_V200_MAC,
+            'eth_dst': self.P2_V200_MAC,
+            'vid': 200
+            })
+
+        # reload the config
+        with open(self.config_file, 'w') as f:
+            f.write(self.CONFIG)
+        _, new_dps = dp_parser(self.config_file, 'test_valve')
+        ofmsgs = self.valve.reload_config(new_dps[0])
+        self.table.apply_ofmsgs(ofmsgs)
+
+        # relearn some mac addresses
+        self.rcv_packet(1, 100, {
+            'eth_src': self.P1_V100_MAC,
+            'eth_dst': self.UNKNOWN_MAC
+            })
+        self.rcv_packet(2, 200, {
+            'eth_src': self.P2_V200_MAC,
+            'eth_dst': self.P3_V200_MAC,
+            'vid': 200
+            })
+        self.rcv_packet(3, 200, {
+            'eth_src': self.P3_V200_MAC,
+            'eth_dst': self.P2_V200_MAC,
+            'vid': 200
+            })
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I have rebuilt the original valve unit tests.

This involves using a custom made simulation of a flow table, modelled on OVS's ofproto/trace command. The goal here is to have a system that does not require root to be run.

If there is another openflow 1.3 dp implementation that supports an ofproto/trace like function and can be run entirely in user space we should probably use that instead.

However I dont think supporting this will be too onerous. I have tried to make everything as explicit and as easy to understand as possible.

The unit tests currently only cover basic switching/vlan functions.