### PR TITLE
Add vlan acls

### DIFF
--- a/src/ryu_faucet/org/onfsdn/faucet/dp.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/dp.py
@@ -33,8 +33,9 @@ class DP(Conf):
     dp_id = None
     configured = False
     table_offset = None
+    port_acl_table = None
     vlan_table = None
-    acl_table = None
+    vlan_acl_table = None
     eth_src_table = None
     ipv4_fib_table = None
     ipv6_fib_table = None
@@ -53,9 +54,10 @@ class DP(Conf):
         # Name for this dp, used for stats reporting and configuration
         'name': None,
         'table_offset': 0,
+        'port_acl_table': None,
         # The table for internally associating vlans
         'vlan_table': None,
-        'acl_table': None,
+        'vlan_acl_table': None,
         'eth_src_table': None,
         'ipv4_fib_table': None,
         'ipv6_fib_table': None,
@@ -98,7 +100,8 @@ class DP(Conf):
         self.acls = {}
         self.vlans = {}
         self.ports = {}
-        self.acl_in = {}
+        self.port_acl_in = {}
+        self.vlan_acl_in = {}
 
     def sanity_check(self):
         # TODO: this shouldnt use asserts
@@ -118,9 +121,10 @@ class DP(Conf):
         # fix special cases
         self._set_default('dp_id', self._id)
         self._set_default('name', str(self._id))
-        self._set_default('vlan_table', self.table_offset)
-        self._set_default('acl_table', self.table_offset + 1)
-        self._set_default('eth_src_table', self.acl_table + 1)
+        self._set_default('port_acl_table', self.table_offset)
+        self._set_default('vlan_table', self.port_acl_table + 1)
+        self._set_default('vlan_acl_table', self.vlan_table + 1)
+        self._set_default('eth_src_table', self.vlan_acl_table + 1)
         self._set_default('ipv4_fib_table', self.eth_src_table + 1)
         self._set_default('ipv6_fib_table', self.ipv4_fib_table + 1)
         self._set_default('eth_dst_table', self.ipv6_fib_table + 1)
@@ -142,10 +146,12 @@ class DP(Conf):
             # other configuration entries ignored
             return
         if port.acl_in is not None:
-            self.acl_in[port_num] = port.acl_in
+            self.port_acl_in[port_num] = port.acl_in
 
     def add_vlan(self, vlan):
         self.vlans[vlan.vid] = vlan
+        if vlan.acl_in is not None:
+            self.vlan_acl_in[vlan.vid] = vlan.acl_in
 
     def resolve_stack_topology(self, dps):
 

--- a/src/ryu_faucet/org/onfsdn/faucet/valve.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/valve.py
@@ -129,7 +129,7 @@ class Valve(object):
 
     def _in_port_tables(self):
         """Return list of tables that specify in_port as a match."""
-        in_port_tables = [self.dp.acl_table]
+        in_port_tables = [self.dp.port_acl_table, self.dp.vlan_acl_table]
         for table_id, match_types in self.TABLE_MATCH_TYPES.iteritems():
             if 'in_port' in match_types:
                 in_port_tables.append(table_id)
@@ -176,7 +176,8 @@ class Valve(object):
             in_port, vlan, eth_type, eth_src,
             eth_dst, eth_dst_mask, ipv6_nd_target, icmpv6_type,
             nw_proto, nw_src, nw_dst)
-        if table_id != self.dp.acl_table:
+        if table_id != self.dp.port_acl_table\
+                and table_id != self.dp.vlan_acl_table:
             assert table_id in self.TABLE_MATCH_TYPES,\
                 '%u table not registered' % table_id
             for match_type in match_dict.iterkeys():
@@ -207,7 +208,8 @@ class Valve(object):
         """
         return (
             self.dp.vlan_table,
-            self.dp.acl_table,
+            self.dp.port_acl_table,
+            self.dp.vlan_acl_table,
             self.dp.eth_src_table,
             self.dp.ipv4_fib_table,
             self.dp.ipv6_fib_table,
@@ -327,6 +329,23 @@ class Valve(object):
 
         return ofmsgs
 
+    def _add_vlan_acl(self, vid):
+        ofmsgs = []
+        if vid in self.dp.vlan_acl_in:
+            acl_num = self.dp.vlan_acl_in[vid]
+            acl_rule_priority = self.dp.highest_priority
+            acl_allow_inst = valve_of.goto_table(self.dp.eth_src_table)
+            for rule_conf in self.dp.acls[acl_num].rules:
+                acl_match, acl_inst = valve_acl.build_acl_entry(
+                    rule_conf, acl_allow_inst, vlan_vid=vid)
+                ofmsgs.append(self.valve_flowmod(
+                    self.dp.vlan_acl_table,
+                    acl_match,
+                    priority=acl_rule_priority,
+                    inst=acl_inst))
+                acl_rule_priority -= 1
+        return ofmsgs
+
     def _add_vlan_flood_flow(self):
         """Add a flow to flood packets for unknown destinations."""
         return [self.valve_flowmod(
@@ -361,6 +380,8 @@ class Valve(object):
             all_port_nums.add(port.number)
         # install eth_dst_table flood ofmsgs
         ofmsgs.extend(self.flood_manager.build_flood_rules(vlan))
+        # add acl rules
+        ofmsgs.extend(self._add_vlan_acl(vlan.vid))
         # add controller IPs if configured.
         ofmsgs.extend(self._add_controller_ips(vlan.controller_ips, vlan))
         return ofmsgs
@@ -415,6 +436,14 @@ class Valve(object):
         self.logger.info('Configuring %s', util.dpid_log(dp_id))
         ofmsgs = []
         ofmsgs.extend(self._add_default_flows())
+        changed_ports = set([])
+        for port_no in discovered_port_nums:
+            if valve_of.ignore_port(port_no):
+                continue
+            changed_ports.add(port_no)
+        changed_vlans = self.dp.vlans.iterkeys()
+        changes = ([], changed_ports, [], changed_vlans)
+        ofmsgs.extend(self._apply_config_changes(self.dp, changes))
         ofmsgs.extend(self._add_ports_and_vlans(discovered_port_nums))
         self.dp.running = True
         return ofmsgs
@@ -431,22 +460,27 @@ class Valve(object):
 
     def _port_add_acl(self, port_num):
         ofmsgs = []
-        forwarding_table = self.dp.eth_src_table
-        if port_num in self.dp.acl_in:
-            acl_num = self.dp.acl_in[port_num]
-            forwarding_table = self.dp.acl_table
+        acl_allow_inst = valve_of.goto_table(self.dp.vlan_table)
+        if port_num in self.dp.port_acl_in:
+            acl_num = self.dp.port_acl_in[port_num]
             acl_rule_priority = self.dp.highest_priority
-            acl_allow_inst = valve_of.goto_table(self.dp.eth_src_table)
             for rule_conf in self.dp.acls[acl_num].rules:
                 acl_match, acl_inst = valve_acl.build_acl_entry(
                     rule_conf, acl_allow_inst, port_num)
                 ofmsgs.append(self.valve_flowmod(
-                    self.dp.acl_table,
+                    self.dp.port_acl_table,
                     acl_match,
                     priority=acl_rule_priority,
                     inst=acl_inst))
                 acl_rule_priority -= 1
-        return ofmsgs, forwarding_table
+        else:
+            ofmsgs.append(self.valve_flowmod(
+                self.dp.port_acl_table,
+                self.valve_in_match(self.dp.port_acl_table, in_port=port_num),
+                priority=self.dp.highest_priority,
+                inst=[acl_allow_inst]
+                ))
+        return ofmsgs
 
     def _port_add_vlan_rules(self, port, vlan, vlan_vid, vlan_inst):
         ofmsgs = []
@@ -476,7 +510,13 @@ class Valve(object):
             vlan_inst = [valve_of.apply_actions(mirror_act)] + vlan_inst
         return self._port_add_vlan_rules(port, vlan, vlan, vlan_inst)
 
-    def _port_add_vlans(self, port, forwarding_table, mirror_act):
+    def _find_forwarding_table(self, vlan):
+        if vlan.vid in self.dp.vlan_acl_in:
+            return self.dp.vlan_acl_table
+        else:
+            return self.dp.eth_src_table
+
+    def _port_add_vlans(self, port, mirror_act):
         ofmsgs = []
         vlans = self.dp.vlans.values()
         tagged_vlans_with_port = [
@@ -486,11 +526,11 @@ class Valve(object):
         for vlan in tagged_vlans_with_port:
             ofmsgs.extend(self.flood_manager.build_flood_rules(vlan))
             ofmsgs.extend(self._port_add_vlan_tagged(
-                port, vlan, forwarding_table, mirror_act))
+                port, vlan, self._find_forwarding_table(vlan), mirror_act))
         for vlan in untagged_vlans_with_port:
             ofmsgs.extend(self.flood_manager.build_flood_rules(vlan))
             ofmsgs.extend(self._port_add_vlan_untagged(
-                port, vlan, forwarding_table, mirror_act))
+                port, vlan, self._find_forwarding_table(vlan), mirror_act))
         return ofmsgs
 
     def port_add(self, dp_id, port_num, modify=False):
@@ -541,7 +581,7 @@ class Valve(object):
             return ofmsgs
 
         # Add ACL if any.
-        acl_ofmsgs, forwarding_table = self._port_add_acl(port_num)
+        acl_ofmsgs = self._port_add_acl(port_num)
         ofmsgs.extend(acl_ofmsgs)
 
         # If this is a stacking port, accept all VLANs (came from another FAUCET)
@@ -550,7 +590,7 @@ class Valve(object):
                 self.dp.vlan_table,
                 match=self.valve_in_match(self.dp.vlan_table, in_port=port_num),
                 priority=self.dp.low_priority,
-                inst=[valve_of.goto_table(forwarding_table)]))
+                inst=[valve_of.goto_table(self.dp.eth_src_table)]))
             for vlan in self.dp.vlans.values():
                 ofmsgs.extend(self.flood_manager.build_flood_rules(vlan))
         else:
@@ -559,7 +599,7 @@ class Valve(object):
             if port.mirror:
                 mirror_act = [valve_of.output_port(port.mirror)]
             # Add port/to VLAN rules.
-            ofmsgs.extend(self._port_add_vlans(port, forwarding_table, mirror_act))
+            ofmsgs.extend(self._port_add_vlans(port, mirror_act))
         return ofmsgs
 
     def port_delete(self, dp_id, port_num):
@@ -765,10 +805,10 @@ class Valve(object):
             new_dp (DP): new dataplane configuration.
         Returns:
             changes (tuple) of:
-                deleted_ports (list): deleted port numbers.
-                changed_ports (list): changed/added port numbers.
-                deleted_vlans (list): deleted VLAN IDs.
-                changed_vlans (list): changed/added VLAN IDs.
+                deleted_ports (set): deleted port numbers.
+                changed_ports (set): changed/added port numbers.
+                deleted_vlans (set): deleted VLAN IDs.
+                changed_vlans (set): changed/added VLAN IDs.
         """
         changed_acls = {}
         for acl_id, new_acl in new_dp.acls.iteritems():
@@ -778,34 +818,35 @@ class Valve(object):
                 if new_acl != self.dp.acls[acl_id]:
                     changed_acls[acl_id] = new_acl
 
-        changed_ports = []
+        changed_ports = set([])
         for port_no, new_port in new_dp.ports.iteritems():
             if port_no not in self.dp.ports:
                 # Detected a newly configured port
-                changed_ports.append(port_no)
+                changed_ports.add(port_no)
             else:
-                # An existing port has configs changed
                 if new_port != self.dp.ports[port_no]:
-                    changed_ports.append(port_no)
-                else:
-                     # If the port has its ACL changed
-                    if new_port.acl_in in changed_acls:
-                        changed_ports.append(port_no)
+                    # An existing port has configs changed
+                    changed_ports.add(port_no)
+                elif new_port.acl_in in changed_acls:
+                    # If the port has its ACL changed
+                    changed_ports.add(port_no)
 
-        deleted_ports = []
-        for port_no in self.dp.ports.iterkeys():
-            if port_no not in new_dp.ports:
-                deleted_ports.append(port_no)
-
-        changed_vlans = []
-        for vid, new_vlan in new_dp.vlans.iteritems():
-            if vid not in self.dp.vlans or new_vlan != self.dp.vlans[vid]:
-                changed_vlans.append(vid)
-
-        deleted_vlans = []
+        deleted_vlans = set([])
         for vid in self.dp.vlans.iterkeys():
             if vid not in new_dp.vlans:
-                deleted_vlans.append(vid)
+                deleted_vlans.add(vid)
+
+        changed_vlans = set([])
+        for vid, new_vlan in new_dp.vlans.iteritems():
+            if vid not in self.dp.vlans or new_vlan != self.dp.vlans[vid]:
+                changed_vlans.add(vid)
+            for p in new_vlan.get_ports():
+                changed_ports.add(p.number)
+
+        deleted_ports = set([])
+        for port_no in self.dp.ports.iterkeys():
+            if port_no not in new_dp.ports:
+                deleted_ports.add(port_no)
 
         changes = (deleted_ports, changed_ports, deleted_vlans, changed_vlans)
         return changes

--- a/src/ryu_faucet/org/onfsdn/faucet/valve_acl.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/valve_acl.py
@@ -32,7 +32,15 @@ class ACL(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-def build_acl_entry(rule_conf, acl_allow_inst, port_num):
+# TODO: change this, maybe this can be rewritten easily
+# possibly replace with a class for ACLs
+# PLAN!
+# You can have port acls, vlan acls and datapath acls.
+# port acls happen first
+# vlan acls are in a new table following the port acls
+# then datapath acls can be whatever the fuck you want and happen after
+# vlan acls
+def build_acl_entry(rule_conf, acl_allow_inst, port_num=None, vlan_vid=None):
     acl_inst = []
     match_dict = {}
     for attrib, attrib_value in rule_conf.iteritems():
@@ -72,7 +80,9 @@ def build_acl_entry(rule_conf, acl_allow_inst, port_num):
                 acl_inst.append(acl_allow_inst)
         else:
             match_dict[attrib] = attrib_value
-    # override in_port always
-    match_dict['in_port'] = port_num
+    if port_num is not None:
+        match_dict['in_port'] = port_num
+    if vlan_vid is not None:
+        match_dict['vlan_vid'] = valve_of.vid_present(vlan_vid)
     acl_match = valve_of.match_from_dict(match_dict)
     return acl_match, acl_inst

--- a/src/ryu_faucet/org/onfsdn/faucet/vlan.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/vlan.py
@@ -26,13 +26,14 @@ class VLAN(Conf):
     bgp_as = None
     bgp_port = None
     bgp_routerid = None
-    bgp_neighbor_addresses = []
-    bgp_neighbour_addresses = []
+    bgp_neighbor_address = None
+    bgp_neighbour_address = None
     bgp_neighbor_as = None
     bgp_neighbour_as = None
     routes = None
     max_hosts = None
     unicast_flood = None
+    acl_in = None
     # Define dynamic variables with prefix dyn_ to distinguish from variables set
     # configuration
     dyn_ipv4_routes = None
@@ -44,13 +45,14 @@ class VLAN(Conf):
     defaults = {
         'name': None,
         'description': None,
+        'acl_in': None,
         'controller_ips': None,
         'unicast_flood': True,
         'bgp_as': 0,
         'bgp_port': 9179,
         'bgp_routerid': '',
-        'bgp_neighbour_addresses': [],
-        'bgp_neighbor_addresses': [],
+        'bgp_neighbour_address': '',
+        'bgp_neighbor_address': None,
         'bgp_neighbour_as': 0,
         'bgp_neighbor_as': None,
         'routes': None,
@@ -81,8 +83,7 @@ class VLAN(Conf):
         if self.bgp_as:
             assert self.bgp_port
             assert ipaddr.IPv4Address(self.bgp_routerid)
-            for neighbor_ip in self.bgp_neighbor_addresses:
-                assert ipaddr.IPAddress(neighbor_ip)
+            assert ipaddr.IPAddress(self.bgp_neighbor_address)
             assert self.bgp_neighbor_as
 
         if self.routes:
@@ -143,7 +144,7 @@ class VLAN(Conf):
         self._set_default('name', str(self._id))
         self._set_default('controller_ips', [])
         self._set_default('bgp_neighbor_as', self.bgp_neighbour_as)
-        self._set_default('bgp_neighbor_addresses', self.bgp_neighbour_addresses)
+        self._set_default('bgp_neighbor_address', self.bgp_neighbour_address)
 
     def __str__(self):
         port_list = [str(x) for x in self.get_ports()]

--- a/tests/config/testconfig.yaml
+++ b/tests/config/testconfig.yaml
@@ -48,6 +48,7 @@ vlans:
         max_hosts: 20
     41:
         name: 'v41'
+        acl_in: 1
         controller_ips: ['10.0.0.253/24']
         bgp_port: 9179
         bgp_as: 1

--- a/tests/config/testconfigv2-vlans.yaml
+++ b/tests/config/testconfigv2-vlans.yaml
@@ -6,6 +6,7 @@ vlans:
         max_hosts: 20
     41:
         name: 'v41'
+        acl_in: 'acl1'
         controller_ips: ['10.0.0.253/24']
         bgp_port: 9179
         bgp_as: 1

--- a/tests/fakeoftable.py
+++ b/tests/fakeoftable.py
@@ -38,7 +38,7 @@ class FakeOFTable():
         for ofmsg in ofmsgs:
             if isinstance(ofmsg, parser.OFPFlowMod):
                 table_id = ofmsg.table_id
-                if table_id == ofp.OFPTT_ALL:
+                if table_id == ofp.OFPTT_ALL or table_id is None:
                     tables = self.tables
                 else:
                     tables = [self.tables[table_id]]
@@ -349,7 +349,7 @@ class FlowMod(object):
             if val is -1:
                 val = Bits(int=-1, length=32)
             elif isinstance(val, str):
-                val = Bits(bytes=addrconv.mac.text_to_bin(val), length=32)
+                val = Bits(bytes=addrconv.ipv4.text_to_bin(val), length=32)
 
         elif key in self.IPV6_MATCH_FIELDS:
             if val is -1:

--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -505,7 +505,7 @@ vlans:
         bgp_port: 9179
         bgp_as: 1
         bgp_routerid: "1.1.1.1"
-        bgp_neighbor_addresses: ["127.0.0.1"]
+        bgp_neighbor_address: "127.0.0.1"
         bgp_neighbor_as: 2
         routes:
             - route:
@@ -578,7 +578,7 @@ vlans:
         bgp_port: 9179
         bgp_as: 1
         bgp_routerid: "1.1.1.1"
-        bgp_neighbor_addresses: ["127.0.0.1"]
+        bgp_neighbor_address: "127.0.0.1"
         bgp_neighbor_as: 2
         routes:
             - route:
@@ -1349,7 +1349,7 @@ vlans:
         bgp_port: 9179
         bgp_as: 1
         bgp_routerid: "1.1.1.1"
-        bgp_neighbor_addresses: ["::1"]
+        bgp_neighbor_address: "::1"
         bgp_neighbor_as: 2
 """
 
@@ -1465,7 +1465,7 @@ vlans:
         bgp_port: 9179
         bgp_as: 1
         bgp_routerid: "1.1.1.1"
-        bgp_neighbor_addresses: ["::1"]
+        bgp_neighbor_address: "::1"
         bgp_neighbor_as: 2
         routes:
             - route:
@@ -1645,6 +1645,14 @@ class FaucetStringOfDPTest(FaucetTest):
         """Set up Mininet and Faucet for the given topology."""
 
         self.dpids = [str(random.randint(1, 2**32)) for _ in range(n_dps)]
+
+        self.topo = FaucetStringOfDPSwitchTopo(
+            dpids=self.dpids,
+            n_tagged=n_tagged,
+            tagged_vid=tagged_vid,
+            n_untagged=n_untagged,
+        )
+
         self.CONFIG = self.get_config(
             self.dpids,
             stack,
@@ -1660,13 +1668,6 @@ class FaucetStringOfDPTest(FaucetTest):
             acl_in_dp,
         )
         open(os.environ['FAUCET_CONFIG'], 'w').write(self.CONFIG)
-        self.topo = FaucetStringOfDPSwitchTopo(
-            dpids=self.dpids,
-            n_tagged=n_tagged,
-            tagged_vid=tagged_vid,
-            n_untagged=n_untagged,
-        )
-
 
     def get_config(self, dpids=[], stack=False, hardware=None, ofchannel_log=None,
                    n_tagged=0, tagged_vid=0, n_untagged=0, untagged_vid=0,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -210,11 +210,21 @@ class DistConfigTestCase(unittest.TestCase):
                 vlan.ipv4_routes
                 )
 
-    def test_acl(self):
+    def test_port_acl(self):
         for dp in (self.v1_dp, self.v2_dp):
-            self.assertIn(1, dp.acl_in)
+            self.assertIn(1, dp.port_acl_in)
             self.assertIn(dp.ports[1].acl_in, dp.acls)
-            self.assertEquals(dp.acls[dp.ports[1].acl_in].rules[0]['nw_dst'], '172.0.0.0/8')
+            self.assertEquals(
+                dp.acls[dp.ports[1].acl_in].rules[0]['nw_dst'],
+                '172.0.0.0/8')
+
+    def test_vlan_acl(self):
+        for dp in (self.v1_dp, self.v2_dp):
+            self.assertIn(41, dp.vlan_acl_in)
+            self.assertIn(dp.vlans[41].acl_in, dp.acls)
+            self.assertEquals(
+                dp.acls[dp.vlans[41].acl_in].rules[0]['nw_dst'],
+                '172.0.0.0/8')
 
     def test_gauge_port_stats(self):
         for watcher in self.v1_watchers:


### PR DESCRIPTION
    Yet another supercommit.. Sorry!

    The table structure now goes:

            |
            V
        port_acl_table
            |
            V
        vlan_table-------+
            |            |
            V            |
        vlan_acl_table   |
            |            |
            |   +--------+
            V   V
        eth_src_table
            |
            V
        etc.

    Some other changes:
        - Use sets rather than lists in _get_config_changes
        - use None rather than [] as default values in config
            classes
        - Add a port_acl test to test_valve.py
        - Start moving towards separate classes for each test in
            test_valve.py
        - use hexadecimal vlan numbers in test_valve.py (this
            was helpful for debugging bitstrings)