### PR TITLE
Throw away unsupported statistics returned by OpenvSwitch.

### DIFF
--- a/src/ryu_faucet/org/onfsdn/faucet/watcher.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/watcher.py
@@ -331,6 +331,10 @@ class GaugePortStatsInfluxDBPoller(GaugePoller, InfluxShipper):
                     ("dropped_out", stat.tx_dropped),
                     ("dropped_in", stat.rx_dropped),
                     ("errors_in", stat.rx_errors)):
+                if stat_value == 2**64-1:
+                    # For openvswitch, unsupported statistics are set to
+                    # all-1-bits (UINT64_MAX), skip reporting them
+                    continue
                 points.append({
                     "measurement": stat_name,
                     "tags": port_tags,


### PR DESCRIPTION
OpenvSwitch indicates unsupported statistics by returning UINT64_MAX which currently crashes Gauge due to #355 and #353.

This PR fixes one part of the equation.