### PR TITLE
use GROUP tables for FIB and VLAN flooding

### DIFF
--- a/src/ryu_faucet/org/onfsdn/faucet/dp.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/dp.py
@@ -51,6 +51,7 @@ class DP(Conf):
     drop_spoofed_faucet_mac = None
     drop_bpdu = None
     drop_lldp = None
+    group_table = False
 
     # Values that are set to None will be set using set_defaults
     # they are included here for testing and informational purposes
@@ -104,6 +105,8 @@ class DP(Conf):
         'drop_bpdu': True,
         # By default, drop LLDP. Set to False, to enable NFV offload of LLDP.
         'drop_lldp': True,
+        #Use GROUP tables for IP routing and vlan flooding
+        'group_table': False,
         }
 
     def __init__(self, _id, conf):

--- a/src/ryu_faucet/org/onfsdn/faucet/valve.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/valve.py
@@ -86,17 +86,20 @@ class Valve(object):
             self.dp.ipv4_fib_table, self.dp.eth_src_table, self.dp.eth_dst_table,
             self.dp.highest_priority,
             self.valve_in_match, self.valve_flowdel, self.valve_flowmod,
-            self.valve_flowcontroller)
+            self.valve_flowcontroller,
+            self.dp.group_table)
         self.ipv6_route_manager = valve_route.ValveIPv6RouteManager(
             self.logger, self.FAUCET_MAC, self.dp.arp_neighbor_timeout,
             self.dp.ipv6_fib_table, self.dp.eth_src_table, self.dp.eth_dst_table,
             self.dp.highest_priority,
             self.valve_in_match, self.valve_flowdel, self.valve_flowmod,
-            self.valve_flowcontroller)
+            self.valve_flowcontroller,
+            self.dp.group_table)
         self.flood_manager = valve_flood.ValveFloodManager(
             self.dp.flood_table, self.dp.low_priority,
             self.valve_in_match, self.valve_flowmod,
-            self.dp.stack, self.dp.ports, self.dp.shortest_path_to_root)
+            self.dp.stack, self.dp.ports, self.dp.shortest_path_to_root,
+            self.dp.group_table)
         self.host_manager = valve_host.ValveHostManager(
             self.logger, self.dp.eth_src_table, self.dp.eth_dst_table,
             self.dp.timeout, self.dp.low_priority, self.dp.highest_priority,
@@ -279,6 +282,7 @@ class Valve(object):
         ofmsgs = []
         for table_id in self._all_valve_tables():
             ofmsgs.extend(self.valve_flowdel(table_id))
+        ofmsgs.append(valve_of.groupdel())
         return ofmsgs
 
     def _delete_all_port_match_flows(self, port):

--- a/src/ryu_faucet/org/onfsdn/faucet/valve_of.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/valve_of.py
@@ -23,6 +23,8 @@ from ryu.ofproto import ether
 from ryu.ofproto import ofproto_v1_3 as ofp
 from ryu.ofproto import ofproto_v1_3_parser as parser
 
+VLAN_GROUP_OFFSET = 4096
+ROUTE_GROUP_OFFSET = VLAN_GROUP_OFFSET * 2
 
 def ignore_port(port_num):
     """Return True if FAUCET should ignore this port.
@@ -258,3 +260,37 @@ def flowmod(cookie, command, table_id, priority, out_port, out_group,
         instructions=inst,
         hard_timeout=hard_timeout,
         idle_timeout=idle_timeout)
+
+def group_act(group_id):
+    return parser.OFPActionGroup(group_id)
+
+def bucket(weight=0, watch_port=ofp.OFPP_ANY,
+        watch_group=ofp.OFPG_ANY, actions=None):
+    return parser.OFPBucket(
+            weight=weight,
+            watch_port=watch_port,
+            watch_group=watch_group,
+            actions=actions)
+
+def groupmod(datapath=None, type_=ofp.OFPGT_ALL, group_id=0, buckets=None):
+    return parser.OFPGroupMod(
+            datapath,
+            ofp.OFPGC_MODIFY,
+            type_,
+            group_id,
+            buckets)
+
+def groupadd(datapath=None, type_=ofp.OFPGT_ALL, group_id=0, buckets=None):
+    return parser.OFPGroupMod(
+            datapath,
+            ofp.OFPGC_ADD,
+            type_,
+            group_id,
+            buckets)
+
+def groupdel(datapath=None, group_id=ofp.OFPG_ALL):
+    return parser.OFPGroupMod(
+            datapath,
+            ofp.OFPGC_DELETE,
+            0,
+            group_id)

--- a/tests/faucet_mininet_test_base.py
+++ b/tests/faucet_mininet_test_base.py
@@ -244,6 +244,43 @@ dbs:
         """Return control URL for Ryu ofctl module."""
         return 'http://127.0.0.1:%u' % self.get_controller().ofctl_port
 
+    def get_all_groups_desc_from_dpid(self, dpid, timeout=2):
+        int_dpid = faucet_mininet_test_util.str_int_dpid(dpid)
+        for _ in range(timeout):
+            try:
+                ofctl_result = json.loads(requests.get(
+                    '%s/stats/groupdesc/%s' % (self.ofctl_rest_url(),
+                                               int_dpid)).text)
+                flow_dump = ofctl_result[int_dpid]
+                return [json.dumps(flow) for flow in flow_dump]
+            except (ValueError, requests.exceptions.ConnectionError):
+                # Didn't get valid JSON, try again
+                time.sleep(1)
+                continue
+        return []
+
+    def get_group_id_for_matching_flow(self, exp_flow, timeout=10):
+        for _ in range(timeout):
+            flow_dump = self.get_all_flows_from_dpid(self.dpid, timeout)
+            for flow in flow_dump:
+                if re.search(exp_flow, flow):
+                    flow = json.loads(flow)
+                    group_id = int(re.findall(r'\d+', str(flow['actions']))[0])
+                    return group_id
+            time.sleep(1)
+        self.assertTrue(False,
+                "Can't find group_id for matching flow %s" % exp_flow)
+
+    def wait_matching_in_group_table(self, exp_flow, group_id, timeout=5):
+        exp_group = '%s.+"group_id": %d' % (exp_flow, group_id)
+        for _ in range(timeout):
+            group_dump = self.get_all_groups_desc_from_dpid(self.dpid, 1)
+            for group_desc in group_dump:
+                if re.search(exp_group, group_desc):
+                    return True
+            time.sleep(1)
+        return False
+
     def get_all_flows_from_dpid(self, dpid, timeout=10):
         """Return all flows from DPID."""
         for _ in range(timeout):
@@ -528,7 +565,8 @@ dbs:
                 return
         self.assertEquals(0, loss)
 
-    def wait_for_route_as_flow(self, nexthop, prefix, timeout=5):
+    def wait_for_route_as_flow(self, nexthop, prefix, timeout=5,
+                               with_group_table=False):
         """Verify a route has been added as a flow."""
         if prefix.version == 6:
             exp_prefix = '/'.join(
@@ -537,8 +575,13 @@ dbs:
         else:
             exp_prefix = prefix.masked().with_netmask
             nw_dst_match = '"nw_dst": "%s"' % exp_prefix
-        self.wait_until_matching_flow(
-            'SET_FIELD: {eth_dst:%s}.+%s' % (nexthop, nw_dst_match), timeout)
+        if with_group_table:
+            group_id = self.get_group_id_for_matching_flow(nw_dst_match)
+            self.wait_matching_in_group_table('SET_FIELD: {eth_dst:%s}' % nexthop,
+                    group_id, timeout)
+        else:
+            self.wait_until_matching_flow(
+                'SET_FIELD: {eth_dst:%s}.+%s' % (nexthop, nw_dst_match), timeout)
 
     def host_ipv4_alias(self, host, alias_ip):
         """Add an IPv4 alias address to a host."""
@@ -550,7 +593,8 @@ dbs:
         self.assertEquals('', host.cmd(add_cmd))
 
     def verify_ipv4_routing(self, first_host, first_host_routed_ip,
-                            second_host, second_host_routed_ip):
+                            second_host, second_host_routed_ip,
+                            with_group_table=False):
         """Verify one host can IPV4 route to another via FAUCET."""
         self.host_ipv4_alias(first_host, first_host_routed_ip)
         self.host_ipv4_alias(second_host, second_host_routed_ip)
@@ -560,13 +604,15 @@ dbs:
             second_host, first_host_routed_ip, self.CONTROLLER_IPV4.ip)
         self.net.ping(hosts=(first_host, second_host))
         self.wait_for_route_as_flow(
-            first_host.MAC(), first_host_routed_ip)
+            first_host.MAC(), first_host_routed_ip,
+            with_group_table=with_group_table)
         self.wait_for_route_as_flow(
-            second_host.MAC(), second_host_routed_ip)
+            second_host.MAC(), second_host_routed_ip,
+            with_group_table=with_group_table)
         self.one_ipv4_ping(first_host, second_host_routed_ip.ip)
         self.one_ipv4_ping(second_host, first_host_routed_ip.ip)
 
-    def verify_ipv4_routing_mesh(self):
+    def verify_ipv4_routing_mesh(self, with_group_table=False):
         """Verify hosts can route to each other via FAUCET."""
         host_pair = self.net.hosts[:2]
         first_host, second_host = host_pair
@@ -575,17 +621,21 @@ dbs:
         second_host_routed_ip2 = ipaddr.IPv4Network('10.0.3.1/24')
         self.verify_ipv4_routing(
             first_host, first_host_routed_ip,
-            second_host, second_host_routed_ip)
+            second_host, second_host_routed_ip,
+            with_group_table=with_group_table)
         self.verify_ipv4_routing(
             first_host, first_host_routed_ip,
-            second_host, second_host_routed_ip2)
+            second_host, second_host_routed_ip2,
+            with_group_table=with_group_table)
         self.swap_host_macs(first_host, second_host)
         self.verify_ipv4_routing(
             first_host, first_host_routed_ip,
-            second_host, second_host_routed_ip)
+            second_host, second_host_routed_ip,
+            with_group_table=with_group_table)
         self.verify_ipv4_routing(
             first_host, first_host_routed_ip,
-            second_host, second_host_routed_ip2)
+            second_host, second_host_routed_ip2,
+            with_group_table=with_group_table)
 
     def setup_ipv6_hosts_addresses(self, first_host, first_host_ip,
                                    first_host_routed_ip, second_host,
@@ -602,7 +652,8 @@ dbs:
 
     def verify_ipv6_routing(self, first_host, first_host_ip,
                             first_host_routed_ip, second_host,
-                            second_host_ip, second_host_routed_ip):
+                            second_host_ip, second_host_routed_ip,
+                            with_group_table=False):
         """Verify one host can IPV6 route to another via FAUCET."""
         self.one_ipv6_ping(first_host, second_host_ip.ip)
         self.one_ipv6_ping(second_host, first_host_ip.ip)
@@ -611,9 +662,11 @@ dbs:
         self.add_host_ipv6_route(
             second_host, first_host_routed_ip, self.CONTROLLER_IPV6.ip)
         self.wait_for_route_as_flow(
-            first_host.MAC(), first_host_routed_ip)
+            first_host.MAC(), first_host_routed_ip,
+            with_group_table=with_group_table)
         self.wait_for_route_as_flow(
-            second_host.MAC(), second_host_routed_ip)
+            second_host.MAC(), second_host_routed_ip,
+            with_group_table=with_group_table)
         self.one_ipv6_controller_ping(first_host)
         self.one_ipv6_controller_ping(second_host)
         self.one_ipv6_ping(first_host, second_host_routed_ip.ip)
@@ -621,16 +674,18 @@ dbs:
 
     def verify_ipv6_routing_pair(self, first_host, first_host_ip,
                                  first_host_routed_ip, second_host,
-                                 second_host_ip, second_host_routed_ip):
+                                 second_host_ip, second_host_routed_ip,
+                                 with_group_table=False):
         """Verify hosts can route IPv6 to each other via FAUCET."""
         self.setup_ipv6_hosts_addresses(
             first_host, first_host_ip, first_host_routed_ip,
             second_host, second_host_ip, second_host_routed_ip)
         self.verify_ipv6_routing(
             first_host, first_host_ip, first_host_routed_ip,
-            second_host, second_host_ip, second_host_routed_ip)
+            second_host, second_host_ip, second_host_routed_ip,
+            with_group_table=with_group_table)
 
-    def verify_ipv6_routing_mesh(self):
+    def verify_ipv6_routing_mesh(self, with_group_table=False):
         """Verify IPv6 routing between hosts and multiple subnets."""
         host_pair = self.net.hosts[:2]
         first_host, second_host = host_pair
@@ -641,14 +696,18 @@ dbs:
         second_host_routed_ip2 = ipaddr.IPv6Network('fc00::30:1/112')
         self.verify_ipv6_routing_pair(
             first_host, first_host_ip, first_host_routed_ip,
-            second_host, second_host_ip, second_host_routed_ip)
+            second_host, second_host_ip, second_host_routed_ip,
+            with_group_table=with_group_table)
         self.verify_ipv6_routing_pair(
             first_host, first_host_ip, first_host_routed_ip,
-            second_host, second_host_ip, second_host_routed_ip2)
+            second_host, second_host_ip, second_host_routed_ip2,
+            with_group_table=with_group_table)
         self.swap_host_macs(first_host, second_host)
         self.verify_ipv6_routing_pair(
             first_host, first_host_ip, first_host_routed_ip,
-            second_host, second_host_ip, second_host_routed_ip)
+            second_host, second_host_ip, second_host_routed_ip,
+            with_group_table=with_group_table)
         self.verify_ipv6_routing_pair(
             first_host, first_host_ip, first_host_routed_ip,
-            second_host, second_host_ip, second_host_routed_ip2)
+            second_host, second_host_ip, second_host_routed_ip2,
+            with_group_table=with_group_table)


### PR DESCRIPTION
To enable, add "group_table: True" to each dp's config.
group table is automatically disabled if stacking is used.