### PR TITLE
use TERM instead of KILL

### DIFF
--- a/src/ryu_faucet/org/onfsdn/faucet/faucet.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/faucet.py
@@ -97,7 +97,7 @@ class Faucet(app_manager.RyuApp):
             self.logname, self.logfile, logging.DEBUG, 0)
         # Set up separate logging for exceptions
         self.exc_logger = get_logger(
-            self.exc_logname, self.exc_logfile, logging.CRITICAL, 1)
+            self.exc_logname, self.exc_logfile, logging.DEBUG, 1)
 
         # Set up a valve object for each datapath
         self.valves = {}

--- a/src/ryu_faucet/org/onfsdn/faucet/faucet.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/faucet.py
@@ -182,6 +182,7 @@ class Faucet(app_manager.RyuApp):
             bgp_speaker.neighbor_add(
                 address=bgp_neighbor_address,
                 remote_as=vlan.bgp_neighbor_as,
+		local_address=vlan.bgp_local_address,
                 enable_ipv4=True,
                 enable_ipv6=True)
         return bgp_speaker

--- a/src/ryu_faucet/org/onfsdn/faucet/util.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/util.py
@@ -53,7 +53,7 @@ def kill_on_exception(logname):
                 logging.getLogger(logname).exception(
                     "Unhandled exception, killing RYU")
                 logging.shutdown()
-                os.kill(os.getpid(), signal.SIGKILL)
+                os.kill(os.getpid(), signal.SIGTERM)
         return __koe
     return _koe
 

--- a/src/ryu_faucet/org/onfsdn/faucet/valve_host.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/valve_host.py
@@ -101,6 +101,12 @@ class ValveHostManager(object):
         ofmsgs = []
         in_port = port.number
 
+        # If we've learnt this host within the last second,
+        # then ignore it.
+        if (eth_src in vlan.host_cache
+                and vlan.host_cache[eth_src].cache_time > time.time() - 1):
+            return []
+
         # hosts learned on this port never relearned
         if port.permanent_learn:
             learn_timeout = 0

--- a/src/ryu_faucet/org/onfsdn/faucet/vlan.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/vlan.py
@@ -24,6 +24,7 @@ class VLAN(Conf):
     vid = None
     controller_ips = None
     bgp_as = None
+    bgp_local_address = None
     bgp_port = None
     bgp_routerid = None
     bgp_neighbor_addresses = []
@@ -49,6 +50,7 @@ class VLAN(Conf):
         'controller_ips': None,
         'unicast_flood': True,
         'bgp_as': 0,
+	'bgp_local_address': None,
         'bgp_port': 9179,
         'bgp_routerid': '',
         'bgp_neighbour_addresses': [],


### PR DESCRIPTION
ryu tends to squash errors, and thus not exit.  This wrapper
KILL's itself when it gets exceptions in various places.

Change it so it uses TERM instead of KILL thus messages are cleaned up
cleanly