### PR TITLE
Change logging priority for exceptions in gauge.

### DIFF
--- a/src/ryu_faucet/org/onfsdn/faucet/gauge.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/gauge.py
@@ -65,7 +65,7 @@ class Gauge(app_manager.RyuApp):
             self.logname, self.logfile, logging.DEBUG, 0)
         # Set up separate logging for exceptions
         self.exc_logger = get_logger(
-            self.exc_logname, self.exc_logfile, logging.CRITICAL, 1)
+            self.exc_logname, self.exc_logfile, logging.DEBUG, 1)
 
         # Set the signal handler for reloading config file
         signal.signal(signal.SIGHUP, self.signal_handler)


### PR DESCRIPTION
This means that the exception log doesn't filter out exceptions.