### PR TITLE
Add check_faucet_config.py, which parses a list of FAUCET configs,

### DIFF
--- a/src/ryu_faucet/org/onfsdn/faucet/check_faucet_config.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/check_faucet_config.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python
+
+import logging
+import sys
+
+import valve
+from config_parser import dp_parser
+
+
+def check_config(conf_files):
+    logname = '/dev/null'
+    logger = logging.getLogger('%s.config' % logname)
+    logger_handler = logging.StreamHandler(stream=sys.stderr)
+    logger.addHandler(logger_handler)
+    logger.propagate = 0
+    logger.setLevel(logging.DEBUG)
+
+    for conf_file in conf_files:
+        parse_result = dp_parser(conf_file, logname)
+        if parse_result is None:
+            return False
+        else:
+            _, dps = parse_result
+            for dp in dps:
+                valve_dp = valve.valve_factory(dp)
+                if valve_dp is None:
+                    return False
+                print dp.to_conf()
+    return True
+
+
+if __name__ == '__main__':
+    if check_config(sys.argv[1:]):
+        sys.exit(0)
+    else:
+        sys.exit(-1)


### PR DESCRIPTION
and exits with 0 if all configs can be parsed, or non-0 if not.

faucet@faucet:~/faucet/src/ryu_faucet/org/onfsdn/faucet$ ./check_faucet_config.py /etc/ryu/faucet/faucet.yaml
Error in file /etc/ryu/faucet/faucet.yaml (while scanning for the next token
found character '\t' that cannot start any token
  in "/etc/ryu/faucet/faucet.yaml", line 9, column 1)
faucet@faucet:~/faucet/src/ryu_faucet/org/onfsdn/faucet$ echo $?
255