### PR TITLE
InfluxDB: handle connection errors, and switch from uint64 to float64 to avoid InfluxDB int64 limits.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM osrg/ryu
 RUN \
   apt-get update && \
   apt-get install -qy --no-install-recommends \
+    influxdb \
     libpython2.7-dev \
     libyaml-dev \
     python-paramiko \

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -4,6 +4,7 @@ RUN \
   apt-get update && \
   apt-get install -qy --no-install-recommends \
     git \
+    influxdb \
     iputils-ping \
     libpython2.7-dev \
     libyaml-dev \

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ graphviz
 influxdb
 ipaddr
 networkx
+numpy
 packaging
 pyyaml
 pylint

--- a/src/ryu_faucet/org/onfsdn/faucet/faucet.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/faucet.py
@@ -25,8 +25,9 @@ import signal
 import ipaddr
 
 from config_parser import config_file_hash, dp_parser
+from util import dpid_log, get_logger, kill_on_exception, get_sys_prefix
 from valve import valve_factory
-from util import kill_on_exception, get_sys_prefix, get_logger, dpid_log
+import valve_of
 
 from ryu.base import app_manager
 from ryu.controller.handler import CONFIG_DISPATCHER
@@ -39,7 +40,7 @@ from ryu.lib import hub
 from ryu.lib.packet import ethernet
 from ryu.lib.packet import packet
 from ryu.lib.packet import vlan as ryu_vlan
-from ryu.ofproto import ofproto_v1_3, ether
+from ryu.ofproto import ether
 from ryu.services.protocols.bgp.bgpspeaker import BGPSpeaker
 
 
@@ -144,13 +145,11 @@ class Faucet(app_manager.RyuApp):
     Valve provides the switch implementation; this is a shim for the Ryu
     event handling framework to interface with Valve.
     """
-    OFP_VERSIONS = [ofproto_v1_3.OFP_VERSION]
-
+    OFP_VERSIONS = valve_of.OFP_VERSIONS
     _CONTEXTS = {
         'dpset': dpset.DPSet,
         'faucet_api': FaucetAPI
         }
-
     logname = 'faucet'
     exc_logname = logname + '.exception'
 

--- a/src/ryu_faucet/org/onfsdn/faucet/gauge.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/gauge.py
@@ -19,20 +19,21 @@ import os
 import signal
 
 from ryu.base import app_manager
-from ryu.controller import ofp_event
 from ryu.controller import dpset
 from ryu.controller import event
+from ryu.controller import ofp_event
 from ryu.controller.handler import MAIN_DISPATCHER
 from ryu.controller.handler import set_ev_cls
-from ryu.ofproto import ofproto_v1_3
 
 from config_parser import watcher_parser
-from util import kill_on_exception, get_sys_prefix, get_logger, dpid_log
+from util import dpid_log, get_logger, kill_on_exception, get_sys_prefix
+import valve_of
 from watcher import watcher_factory
 
 
 class EventGaugeReconfigure(event.EventBase):
     pass
+
 
 class Gauge(app_manager.RyuApp):
     """Ryu app for polling Faucet controlled datapaths for stats/state.
@@ -42,10 +43,8 @@ class Gauge(app_manager.RyuApp):
     GAUGE_CONFIG. It logs to the file set as the environment variable
     GAUGE_LOG,
     """
-    OFP_VERSIONS = [ofproto_v1_3.OFP_VERSION]
-
+    OFP_VERSIONS = valve_of.OFP_VERSIONS
     _CONTEXTS = {'dpset': dpset.DPSet}
-
     logname = 'gauge'
     exc_logname = logname + '.exception'
 

--- a/src/ryu_faucet/org/onfsdn/faucet/valve_of.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/valve_of.py
@@ -26,6 +26,7 @@ from ryu.ofproto import ofproto_v1_3_parser as parser
 
 VLAN_GROUP_OFFSET = 4096
 ROUTE_GROUP_OFFSET = VLAN_GROUP_OFFSET * 2
+OFP_VERSIONS = [ofp.OFP_VERSION]
 
 
 def ignore_port(port_num):

--- a/src/ryu_faucet/org/onfsdn/faucet/watcher.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/watcher.py
@@ -74,7 +74,7 @@ class GaugeDBHelper(object):
 
     def setup(self):
         self.conn_string = (
-            "driver={0};server={1};port={2};uid={3};pwd={4}".format(
+            'driver={0};server={1};port={2};uid={3};pwd={4}'.format(
                 self.conf.driver, self.conf.db_ip, self.conf.db_port,
                 self.conf.db_username, self.conf.db_password))
         nsodbc = nsodbc_factory()
@@ -128,7 +128,7 @@ class GaugePortStateLogger(object):
         if self.conf.file:
             rcv_time_str = _rcv_time()
             with open(self.conf.file, 'a') as logfile:
-                logfile.write('%s\t%s\n' % (rcv_time_str, log_msg))
+                logfile.write('\t'.join((rcv_time_str, log_msg)) + '\n')
 
     def start(self, ryudp):
         pass
@@ -149,16 +149,16 @@ class GaugePortStateInfluxDBLogger(GaugePortStateLogger, InfluxShipper):
         if port_no in self.dp.ports:
             port_name = self.dp.ports[port_no].name
             port_tags = {
-                "dp_name": self.dp.name,
-                "port_name": port_name,
+                'dp_name': self.dp.name,
+                'port_name': port_name,
             }
             points = [{
-                "measurement": "port_state_reason",
-                "tags": port_tags,
-                "time": int(rcv_time),
-                "fields": {"value": reason}}]
+                'measurement': 'port_state_reason',
+                'tags': port_tags,
+                'time': int(rcv_time),
+                'fields': {'value': reason}}]
             if not self.ship_points(points):
-                self.logger.warning("error shipping port_state_reason points")
+                self.logger.warning('error shipping port_state_reason points')
 
 
 class GaugePoller(object):
@@ -306,7 +306,8 @@ class GaugePortStatsPoller(GaugePoller):
 
 class GaugePortStatsInfluxDBPoller(GaugePoller, InfluxShipper):
     """Periodically sends a port stats request to the datapath and parses
-       and outputs the response."""
+       and outputs the response.
+    """
 
     def __init__(self, conf, logname):
         super(GaugePortStatsInfluxDBPoller, self).__init__(conf, logname)
@@ -348,7 +349,8 @@ class GaugeFlowTablePoller(GaugePoller):
 
     Includes a timestamp and a reference ($DATAPATHNAME-flowtables). The
     flow table is dumped as an OFFlowStatsReply message (in yaml format) that
-    matches all flows."""
+    matches all flows.
+    """
 
     def __init__(self, conf, logname):
         super(GaugeFlowTablePoller, self).__init__(conf, logname)
@@ -368,12 +370,14 @@ class GaugeFlowTablePoller(GaugePoller):
         self.reply_pending = False
         jsondict = msg.to_jsondict()
         rcv_time_str = _rcv_time()
-
         with open(self.conf.file, 'a') as logfile:
-            ref = self.dp.name + "-flowtables"
-            logfile.write("---\n")
-            logfile.write("time: {0}\nref: {1}\nmsg: {2}\n".format(
-                rcv_time_str, ref, json.dumps(jsondict, indent=4)))
+            ref = '-'.join((self.dp.name, 'flowtables'))
+            logfile.write(
+                '\n'.join((
+                    '---',
+                    'time: %s' % rcv_time_str,
+                    'ref: %s' % ref,
+                    'msg: %s' % json.dumps(jsondict, indent=4))))
 
     def no_response(self):
         self.logger.info(
@@ -385,7 +389,8 @@ class GaugeFlowTableDBLogger(GaugePoller, GaugeDBHelper):
 
     Includes a timestamp and a reference ($DATAPATHNAME-flowtables). The
     flow table is dumped as an OFFlowStatsReply message (in yaml format) that
-    matches all flows."""
+    matches all flows.
+    """
 
     def __init__(self, conf, logname):
         super(GaugeFlowTableDBLogger, self).__init__(conf, logname)

--- a/src/ryu_faucet/org/onfsdn/faucet/watcher.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/watcher.py
@@ -69,11 +69,13 @@ class InfluxShipper(object):
             'dp_name': dp_name,
             'port_name': port_name,
         }
+        # InfluxDB has only one integer type, int64. We are logging OF
+        # stats that are uint64. Use float to prevent an overflow.
         point = {
             'measurement': stat_name,
             'tags': port_tags,
             'time': int(rcv_time),
-            'fields': {'value': stat_val}}
+            'fields': {'value': float(stat_val)}}
         return point
 
 

--- a/src/ryu_faucet/org/onfsdn/faucet/watcher.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/watcher.py
@@ -3,6 +3,8 @@ import random
 import json
 import time
 
+import numpy
+
 from influxdb import InfluxDBClient
 from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
 from requests.exceptions import ConnectionError
@@ -70,12 +72,13 @@ class InfluxShipper(object):
             'port_name': port_name,
         }
         # InfluxDB has only one integer type, int64. We are logging OF
-        # stats that are uint64. Use float to prevent an overflow.
+        # stats that are uint64. Use float64 to prevent an overflow.
+        # q.v. https://docs.influxdata.com/influxdb/v1.2/write_protocols/line_protocol_reference/
         point = {
             'measurement': stat_name,
             'tags': port_tags,
             'time': int(rcv_time),
-            'fields': {'value': float(stat_val)}}
+            'fields': {'value': numpy.float64(stat_val)}}
         return point
 
 

--- a/src/ryu_faucet/org/onfsdn/faucet/watcher.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/watcher.py
@@ -3,9 +3,10 @@ import random
 import json
 import time
 
+from influxdb import InfluxDBClient
+from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
 from requests.exceptions import ConnectionError
 from ryu.lib import hub
-from influxdb import InfluxDBClient
 from nsodbc import nsodbc_factory, init_switch_db, init_flow_db
 
 
@@ -60,7 +61,7 @@ class InfluxShipper(object):
                 database=self.conf.influx_db,
                 timeout=self.conf.influx_timeout)
             return client.write_points(points=points, time_precision='s')
-        except ConnectionError:
+        except (ConnectionError, InfluxDBClientError, InfluxDBServerError):
             return False
 
     def make_point(self, dp_name, port_name, rcv_time, stat_name, stat_val):

--- a/src/ryu_faucet/org/onfsdn/faucet/watcher.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/watcher.py
@@ -155,6 +155,25 @@ class GaugePortStateLogger(object):
 
 
 class GaugePortStateInfluxDBLogger(GaugePortStateLogger, InfluxShipper):
+    """
+> use faucet
+Using database faucet
+> precision rfc3339
+> select * from port_state_reason where port_name = 'port1.0.1' order by time desc limit 10;
+name: port_state_reason
+-----------------------
+time			dp_name			port_name	value
+2017-02-21T02:12:29Z	windscale-faucet-1	port1.0.1	2
+2017-02-21T02:12:25Z	windscale-faucet-1	port1.0.1	2
+2016-07-27T22:05:08Z	windscale-faucet-1	port1.0.1	2
+2016-05-25T04:33:00Z	windscale-faucet-1	port1.0.1	2
+2016-05-25T04:32:57Z	windscale-faucet-1	port1.0.1	2
+2016-05-25T04:31:21Z	windscale-faucet-1	port1.0.1	2
+2016-05-25T04:31:18Z	windscale-faucet-1	port1.0.1	2
+2016-05-25T04:27:07Z	windscale-faucet-1	port1.0.1	2
+2016-05-25T04:27:04Z	windscale-faucet-1	port1.0.1	2
+2016-05-25T04:24:53Z	windscale-faucet-1	port1.0.1	2
+    """
 
     def __init__(self, conf, logname):
         super(GaugePortStateInfluxDBLogger, self).__init__(conf, logname)
@@ -318,6 +337,35 @@ class GaugePortStatsPoller(GaugePoller):
 class GaugePortStatsInfluxDBPoller(GaugePoller, InfluxShipper):
     """Periodically sends a port stats request to the datapath and parses
        and outputs the response.
+
+> use faucet
+Using database faucet
+> show measurements
+name: measurements
+------------------
+bytes_in
+bytes_out
+dropped_in
+dropped_out
+errors_in
+packets_in
+packets_out
+port_state_reason
+> precision rfc3339
+> select * from packets_out where port_name = 'port1.0.1' order by time desc limit 10;
+name: packets_out
+-----------------
+time			dp_name			port_name	value
+2017-03-06T05:21:42Z	windscale-faucet-1	port1.0.1	76083431
+2017-03-06T05:21:33Z	windscale-faucet-1	port1.0.1	76081172
+2017-03-06T05:21:22Z	windscale-faucet-1	port1.0.1	76078727
+2017-03-06T05:21:12Z	windscale-faucet-1	port1.0.1	76076612
+2017-03-06T05:21:02Z	windscale-faucet-1	port1.0.1	76074546
+2017-03-06T05:20:52Z	windscale-faucet-1	port1.0.1	76072730
+2017-03-06T05:20:42Z	windscale-faucet-1	port1.0.1	76070528
+2017-03-06T05:20:32Z	windscale-faucet-1	port1.0.1	76068211
+2017-03-06T05:20:22Z	windscale-faucet-1	port1.0.1	76065982
+2017-03-06T05:20:12Z	windscale-faucet-1	port1.0.1	76063941
     """
 
     def __init__(self, conf, logname):


### PR DESCRIPTION
InfluxDB automatically derives type from the first value inserted, so unfortunately this means timeseries will have to be manually converted.
