### PR TITLE
Added file based storing option for flow tables

### DIFF
--- a/src/cfg/etc/ryu/faucet/gauge.yaml-dist
+++ b/src/cfg/etc/ryu/faucet/gauge.yaml-dist
@@ -15,8 +15,12 @@ watchers:
         type: 'flow_table'
         dps: ['windscale-faucet-1']
         interval: 40
-        db: 'couchdb'
+        #db: 'couchdb'
+        db: 'ft_file'
 dbs:
+    ft_file:
+        type: 'text'
+        file: 'flow_table.JSON'
     influx:
         type: 'influx'
         influx_db: 'faucet'


### PR DESCRIPTION
This is necessary so that developers don’t have to worry about setting
up CouchDB, but have access to flow tables in text format that they can
look at.