### PR TITLE
Implement inter-VLAN routing

### DIFF
--- a/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
@@ -17,6 +17,7 @@ from acl import ACL
 from dp import DP
 from port import Port
 from vlan import VLAN
+from router import Router
 from watcher_conf import WatcherConf
 
 import config_parser_util
@@ -75,7 +76,7 @@ def _dp_add_vlan(vid_dp, dp, vlan):
     vid_dp[vlan.vid].add(dp.name)
 
 
-def _dp_parser_v2(acls_conf, dps_conf, vlans_conf, logger):
+def _dp_parser_v2(logger, acls_conf, dps_conf, routers_conf, vlans_conf):
     dps = []
     vid_dp = {}
     for identifier, dp_conf in dps_conf.iteritems():
@@ -90,7 +91,9 @@ def _dp_parser_v2(acls_conf, dps_conf, vlans_conf, logger):
             acls = []
             for acl_ident, acl_conf in acls_conf.iteritems():
                 acls.append((acl_ident, ACL(acl_ident, acl_conf)))
-
+            routers = []
+            for router_ident, router_conf in routers_conf.iteritems():
+                routers.append((router_ident, Router(router_ident, router_conf)))
             ports_conf = dp_conf.pop('interfaces', {})
             ports = {}
             for port_num, port_conf in ports_conf.iteritems():
@@ -119,6 +122,7 @@ def _config_parser_v2(config_file, logname):
     top_confs = {
         'acls': {},
         'dps': {},
+        'routers': {},
         'vlans': {},
     }
 
@@ -132,7 +136,11 @@ def _config_parser_v2(config_file, logname):
         return None
 
     dps = _dp_parser_v2(
-        top_confs['acls'], top_confs['dps'], top_confs['vlans'], logger)
+        logger,
+        top_confs['acls'],
+        top_confs['dps'],
+        top_confs['routers'],
+        top_confs['vlans'])
     return (config_hashes, dps)
 
 

--- a/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
@@ -26,19 +26,11 @@ def dp_parser(config_file, logname):
     conf = config_parser_util.read_config(config_file, logname)
     if conf is None:
         return None
-
     version = conf.pop('version', 2)
-    config_hashes = None
-    dps = None
+    if version != 2:
+        logger.fatal('Only config version 2 is supported')
 
-    if version == 1:
-        logger.fatal(
-            'Version 1 config is UNSUPPORTED. Please move to version 2')
-    elif version == 2:
-        config_hashes, dps = _config_parser_v2(config_file, logname)
-    else:
-        logger.error('unsupported config version number %s', version)
-
+    config_hashes, dps = _config_parser_v2(config_file, logname)
     if dps is not None:
         for dp in dps:
             try:
@@ -47,7 +39,6 @@ def dp_parser(config_file, logname):
                 logger.exception('Error finalizing datapath configs: %s', err)
         for dp in dps:
             dp.resolve_stack_topology(dps)
-
     return config_hashes, dps
 
 

--- a/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
@@ -97,7 +97,7 @@ def _dp_parser_v2(logger, acls_conf, dps_conf, routers_conf, vlans_conf):
             if routers:
                 assert len(routers) == 1, 'only one router supported'
                 router_ident, router = routers[0]
-                assert router.vlans == vlans.keys(), 'only global routing supported'
+                assert set(router.vlans) == set(vlans.keys()), 'only global routing supported'
                 dp.add_router(router_ident, router)
             ports_conf = dp_conf.pop('interfaces', {})
             ports = {}

--- a/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/config_parser.py
@@ -94,6 +94,11 @@ def _dp_parser_v2(logger, acls_conf, dps_conf, routers_conf, vlans_conf):
             routers = []
             for router_ident, router_conf in routers_conf.iteritems():
                 routers.append((router_ident, Router(router_ident, router_conf)))
+            if routers:
+                assert len(routers) == 1, 'only one router supported'
+                router_ident, router = routers[0]
+                assert router.vlans == vlans.keys(), 'only global routing supported'
+                dp.add_router(router_ident, router)
             ports_conf = dp_conf.pop('interfaces', {})
             ports = {}
             for port_num, port_conf in ports_conf.iteritems():

--- a/src/ryu_faucet/org/onfsdn/faucet/dp.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/dp.py
@@ -165,9 +165,8 @@ class DP(Conf):
         self._set_default('highest_priority', self.high_priority + 98)
         self._set_default('description', self.name)
 
-    def add_acl(self, acl_ident, acl_conf=None):
-        if acl_conf is not None:
-            self.acls[acl_ident] = ACL(acl_ident, acl_conf)
+    def add_acl(self, acl_ident, acl):
+        self.acls[acl_ident] = acl
 
     def add_port(self, port):
         port_num = port.number

--- a/src/ryu_faucet/org/onfsdn/faucet/dp.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/dp.py
@@ -27,6 +27,7 @@ class DP(Conf):
     acls = None
     vlans = None
     ports = None
+    routers = None
     running = False
     influxdb_stats = False
     name = None
@@ -129,6 +130,7 @@ class DP(Conf):
         self.acls = {}
         self.vlans = {}
         self.ports = {}
+        self.routers = {}
         self.stack_ports = []
         self.port_acl_in = {}
         self.vlan_acl_in = {}
@@ -169,6 +171,9 @@ class DP(Conf):
 
     def add_acl(self, acl_ident, acl):
         self.acls[acl_ident] = acl
+
+    def add_router(self, router_ident, router):
+        self.routers[router_ident] = router
 
     def add_port(self, port):
         port_num = port.number

--- a/src/ryu_faucet/org/onfsdn/faucet/dp.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/dp.py
@@ -144,6 +144,8 @@ class DP(Conf):
         for portnum, port in self.ports.iteritems():
             assert isinstance(portnum, int)
             assert isinstance(port, Port)
+        for acl in self.acls.itervalues():
+            assert isinstance(acl, ACL)
 
     def set_defaults(self):
         for key, value in self.defaults.iteritems():

--- a/src/ryu_faucet/org/onfsdn/faucet/router.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/router.py
@@ -17,18 +17,15 @@ from conf import Conf
 
 class Router(Conf):
 
-    name = None
     vlans = None
 
     defaults = {
-        'name': None,
         'vlans': None
         }
 
-    def __init__(self, _id, name, conf=None):
+    def __init__(self, _id, conf=None):
         if conf is None:
             conf = {}
-        self.name = name
         self.update(conf)
         self._id = _id
 

--- a/src/ryu_faucet/org/onfsdn/faucet/router.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/router.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2015 Brad Cowie, Christopher Lorier and Joe Stringer.
+# Copyright (C) 2015 Research and Education Advanced Network New Zealand Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from conf import Conf
+
+class Router(Conf):
+
+    name = None
+    vlans = None
+
+    defaults = {
+        'name': None,
+        'vlans': None
+        }
+
+    def __init__(self, _id, name, conf=None):
+        if conf is None:
+            conf = {}
+        self.name = name
+        self.update(conf)
+        self._id = _id
+
+    def to_conf(self):
+        return self._to_conf()

--- a/src/ryu_faucet/org/onfsdn/faucet/valve.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/valve.py
@@ -99,7 +99,7 @@ class Valve(object):
             self.dp.highest_priority,
             self.valve_in_match, self.valve_flowdel, self.valve_flowmod,
             self.valve_flowcontroller,
-            self.dp.group_table)
+            self.dp.group_table, self.dp.routers)
         self.ipv6_route_manager = valve_route.ValveIPv6RouteManager(
             self.logger, self.FAUCET_MAC, self.dp.arp_neighbor_timeout,
             self.dp.max_hosts_per_resolve_cycle, self.dp.max_host_fib_retry_count,
@@ -108,7 +108,7 @@ class Valve(object):
             self.dp.highest_priority,
             self.valve_in_match, self.valve_flowdel, self.valve_flowmod,
             self.valve_flowcontroller,
-            self.dp.group_table)
+            self.dp.group_table, self.dp.routers)
         self.flood_manager = valve_flood.ValveFloodManager(
             self.dp.flood_table, self.dp.low_priority,
             self.valve_in_match, self.valve_flowmod,

--- a/src/ryu_faucet/org/onfsdn/faucet/valve_route.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/valve_route.py
@@ -46,7 +46,7 @@ class ValveRouteManager(object):
                  max_resolve_backoff_time,
                  fib_table, eth_src_table, eth_dst_table, route_priority,
                  valve_in_match, valve_flowdel, valve_flowmod,
-                 valve_flowcontroller, use_group_table):
+                 valve_flowcontroller, use_group_table, routers):
         self.logger = logger
         self.faucet_mac = faucet_mac
         self.arp_neighbor_timeout = arp_neighbor_timeout
@@ -62,6 +62,7 @@ class ValveRouteManager(object):
         self.valve_flowmod = valve_flowmod
         self.valve_flowcontroller = valve_flowcontroller
         self.use_group_table = use_group_table
+        self.routers = routers
         self.ip_gw_to_group_id = {}
 
     def _vlan_vid(self, vlan, in_port):

--- a/tests/config/testconfigv2-dps.yaml
+++ b/tests/config/testconfigv2-dps.yaml
@@ -44,3 +44,7 @@ dps:
                 stack:
                      dp: switch1
                      port: 7
+
+routers:
+    router1:
+        vlans: ['v40', 41]


### PR DESCRIPTION
vlans:
    100:
        description: "100"
        faucet_vips: ["10.100.0.254/24"]
    200:
        description: "200"
        faucet_vips: ["10.200.0.254/24"]
routers:
    router-1:
        vlans: [100, 200]

Hosts in VLAN 100 (using a gateway of 10.100.0.254) will be able to reach hosts in VLAN 200 (hosts there using a gateway of 10.200.0.254).

Only one router, routing between all VLANs is currently supported.
