### PR TITLE
MAC mismatch test can fail because host-to-host IPv6 neighbor discove…

### DIFF
--- a/tests/faucet_mininet_test_base.py
+++ b/tests/faucet_mininet_test_base.py
@@ -705,26 +705,33 @@ dbs:
         host.cmd(del_cmd)
         self.assertEquals('', host.cmd(add_cmd))
 
-    def verify_ipv4_host_learned_mac(self, host, ip, mac):
-        learned_mac = host.cmd(
-            "arp -n %s | grep %s | awk '{ print $3 }'" % (ip, ip))
+    def verify_ipv4_host_learned_mac(self, host, ip, mac, retries=3):
+        for _ in range(retries):
+            learned_mac = host.cmd(
+                "arp -n %s | grep %s | awk '{ print $3 }'" % (ip, ip)).strip()
+            if learned_mac:
+                break
+            time.sleep(1)
         self.assertEqual(
-            learned_mac.strip(),
-            mac,
+            mac, learned_mac,
             msg='MAC learned on host mismatch (expected %s found %s)' % (
-                mac, learned_mac.strip()))
+                mac, learned_mac))
 
     def verify_ipv4_host_learned_host(self, host, learned_host):
         learned_ip = ipaddr.IPNetwork(self.host_ipv4(learned_host))
         self.verify_ipv4_host_learned_mac(host, learned_ip.ip, learned_host.MAC())
 
-    def verify_ipv6_host_learned_mac(self, host, ip6, mac):
-        learned_mac = host.cmd(
-            "ip -6 neighbor show %s | awk '{ print $5 }'" % ip6)
+    def verify_ipv6_host_learned_mac(self, host, ip6, mac, retries=3):
+        for _ in range(retries):
+            learned_mac = host.cmd(
+                "ip -6 neighbor show %s | awk '{ print $5 }'" % ip6).strip()
+            if learned_mac:
+                break
+            time.sleep(1)
         self.assertEqual(
-            learned_mac.strip(), mac,
+            mac, learned_mac,
             msg='MAC learned on host mismatch (expected %s found %s)' % (
-                mac, learned_mac.strip()))
+                mac, learned_mac))
 
     def verify_ipv6_host_learned_host(self, host, learned_host):
         learned_ip6 = ipaddr.IPNetwork(self.host_ipv6(learned_host))


### PR DESCRIPTION
…ry hasn't happened yet.