### PR TITLE
Remove hardcoded port_no from faucet_mininet_test.py

### DIFF
--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -1012,7 +1012,7 @@ vlans:
             '"table_id": 7, "match": {"dl_vlan": "100", "in_port": %(port_1)d}' % self.port_map))
         # Unicast flood rule exists that output to port 1
         self.assertTrue(self.matching_flow_present(
-            '"OUTPUT:1".+"table_id": 7, "match": {"dl_vlan": "100", "in_port": .}'))
+            '"OUTPUT:%(port_1)d".+"table_id": 7, "match": {"dl_vlan": "100", "in_port": .+}' % self.port_map))
 
 
 class FaucetUntaggedNoVLanUnicastFloodTest(FaucetUntaggedTest):
@@ -1047,7 +1047,7 @@ vlans:
             '"table_id": 7, "match": {"dl_vlan": "100", "in_port": %(port_1)d}' % self.port_map))
         # No unicast flood rule exists that output to port 1
         self.assertFalse(self.matching_flow_present(
-            '"OUTPUT:1".+"table_id": 7, "match": {"dl_vlan": "100", "in_port": .}'))
+            '"OUTPUT:%(port_1)d".+"table_id": 7, "match": {"dl_vlan": "100", "in_port": .+}' % self.port_map))
 
 
 class FaucetUntaggedPortUnicastFloodTest(FaucetUntaggedTest):
@@ -1085,7 +1085,7 @@ vlans:
             '"table_id": 7, "match": {"dl_vlan": "100", "in_port": %(port_1)d}' % self.port_map))
         # No unicast flood rule exists that output to port 1
         self.assertFalse(self.matching_flow_present(
-            '"OUTPUT:1".+"table_id": 7, "match": {"dl_vlan": "100", "in_port": .}'))
+            '"OUTPUT:%(port_1)d".+"table_id": 7, "match": {"dl_vlan": "100", "in_port": .+}' % self.port_map))
 
 
 class FaucetUntaggedNoPortUnicastFloodTest(FaucetUntaggedTest):
@@ -1123,9 +1123,9 @@ vlans:
             '"table_id": 7, "match": {"dl_vlan": "100", "in_port": %(port_1)d}' % self.port_map))
         # Unicast flood rules present that output to port 2, but NOT to port 1
         self.assertTrue(self.matching_flow_present(
-            '"OUTPUT:2".+"table_id": 7, "match": {"dl_vlan": "100", "in_port": .}'))
+            '"OUTPUT:%(port_2)d".+"table_id": 7, "match": {"dl_vlan": "100", "in_port": .+}' % self.port_map))
         self.assertFalse(self.matching_flow_present(
-            '"OUTPUT:1".+"table_id": 7, "match": {"dl_vlan": "100", "in_port": .}'))
+            '"OUTPUT:%(port_1)d".+"table_id": 7, "match": {"dl_vlan": "100", "in_port": .+}' % self.port_map))
 
 
 class FaucetUntaggedHostMoveTest(FaucetUntaggedTest):

--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -1009,7 +1009,7 @@ vlans:
         self.assertTrue(self.bogus_mac_flooded_to_port1())
         # Unicast flooding rule for from port 1
         self.assertTrue(self.matching_flow_present(
-            '"table_id": 7, "match": {"dl_vlan": "100", "in_port": 1}'))
+            '"table_id": 7, "match": {"dl_vlan": "100", "in_port": %(port_1)d}' % self.port_map))
         # Unicast flood rule exists that output to port 1
         self.assertTrue(self.matching_flow_present(
             '"OUTPUT:1".+"table_id": 7, "match": {"dl_vlan": "100", "in_port": .}'))
@@ -1044,7 +1044,7 @@ vlans:
         self.assertFalse(self.bogus_mac_flooded_to_port1())
         # No unicast flooding rule for from port 1
         self.assertFalse(self.matching_flow_present(
-            '"table_id": 7, "match": {"dl_vlan": "100", "in_port": 1}'))
+            '"table_id": 7, "match": {"dl_vlan": "100", "in_port": %(port_1)d}' % self.port_map))
         # No unicast flood rule exists that output to port 1
         self.assertFalse(self.matching_flow_present(
             '"OUTPUT:1".+"table_id": 7, "match": {"dl_vlan": "100", "in_port": .}'))
@@ -1082,7 +1082,7 @@ vlans:
         self.assertFalse(self.bogus_mac_flooded_to_port1())
         # No unicast flooding rule for from port 1
         self.assertFalse(self.matching_flow_present(
-            '"table_id": 7, "match": {"dl_vlan": "100", "in_port": 1}'))
+            '"table_id": 7, "match": {"dl_vlan": "100", "in_port": %(port_1)d}' % self.port_map))
         # No unicast flood rule exists that output to port 1
         self.assertFalse(self.matching_flow_present(
             '"OUTPUT:1".+"table_id": 7, "match": {"dl_vlan": "100", "in_port": .}'))
@@ -1118,9 +1118,9 @@ vlans:
         self.assertFalse(self.bogus_mac_flooded_to_port1())
         # Unicast flood rule present for port 2, but NOT for port 1
         self.assertTrue(self.matching_flow_present(
-            '"table_id": 7, "match": {"dl_vlan": "100", "in_port": 2}'))
+            '"table_id": 7, "match": {"dl_vlan": "100", "in_port": %(port_2)d}' % self.port_map))
         self.assertFalse(self.matching_flow_present(
-            '"table_id": 7, "match": {"dl_vlan": "100", "in_port": 1}'))
+            '"table_id": 7, "match": {"dl_vlan": "100", "in_port": %(port_1)d}' % self.port_map))
         # Unicast flood rules present that output to port 2, but NOT to port 1
         self.assertTrue(self.matching_flow_present(
             '"OUTPUT:2".+"table_id": 7, "match": {"dl_vlan": "100", "in_port": .}'))

--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -755,11 +755,11 @@ acls:
             flow_p1 = self.get_matching_flow_on_dpid(
                 self.dpid,
                 ('"table_id": 1, "match": '
-                 '{"dl_vlan": "0x0000", "in_port": 1}'))
+                 '{"dl_vlan": "0x0000", "in_port": %(port_1)d}' % self.port_map))
             flow_p3 = self.get_matching_flow_on_dpid(
                 self.dpid,
                 ('"table_id": 1, "match": '
-                 '{"dl_vlan": "0x0000", "in_port": 3}'))
+                 '{"dl_vlan": "0x0000", "in_port": %(port_3)d}' % self.port_map))
             prev_dur_p1 = flow_p1['duration_sec']
             prev_dur_p3 = flow_p3['duration_sec']
             if vid == 200:
@@ -775,11 +775,11 @@ acls:
             flow_p1 = self.get_matching_flow_on_dpid(
                 self.dpid,
                 ('"table_id": 1, "match": '
-                 '{"dl_vlan": "0x0000", "in_port": 1}'))
+                 '{"dl_vlan": "0x0000", "in_port": %(port_1)d}' % self.port_map))
             flow_p3 = self.get_matching_flow_on_dpid(
                 self.dpid,
                 ('"table_id": 1, "match": '
-                 '{"dl_vlan": "0x0000", "in_port": 3}'))
+                 '{"dl_vlan": "0x0000", "in_port": %(port_3)d}' % self.port_map))
             actions = flow_p1.get('actions', '')
             actions = [act for act in actions if 'vlan_vid' in act]
             vid_ = re.findall(r'\d+', str(actions))
@@ -813,7 +813,7 @@ acls:
             self.hup_faucet()
             self.wait_until_matching_flow(
                 ('{"dl_type": 2048, "nw_proto": 17,'
-                 ' "in_port": 1, "tp_dst": %d}' % (8000+i)))
+                 ' "in_port": %d, "tp_dst": %d}' % (self.port_map["port_1"], 8000+i)))
 
 
 class FaucetSingleUntaggedBGPIPv4RouteTest(FaucetUntaggedTest):
@@ -2441,7 +2441,7 @@ class FaucetGroupTableTest(FaucetUntaggedTest):
         self.assertEqual(
             100,
             self.get_group_id_for_matching_flow(
-                '"table_id": 7,.+"dl_vlan": "100"'))
+                '"table_id": 7,.+"dl_dst".+"dl_vlan": "100"'))
 
 
 class FaucetSingleGroupTableUntaggedIPv4RouteTest(FaucetUntaggedTest):


### PR DESCRIPTION
While running the test cases with an hardware switch and using ports different from 1, 2, 3, and 4 I noticed that some test were failing because they were looking for strings like "in_port: 1" or "OUTPUT:1". I replaced all occurrences of these strings using the values in self.port_map instead.

Also, in test FaucetGroupTableTest.test_group_exist the regex string was trying to match the string `'"table_id": 7,.+"dl_vlan": "100"'` but this string may match the wrong flow entry (using group 4196 instead of group 100) depending on the order of the flows in the multipart reply. 
These are the existing flows:
```
{"priority": 9001, "hard_timeout": 0, "byte_count": 0, "duration_sec": 13, "actions": ["GROUP:100"], "duration_nsec": 2000000, "packet_count": 0, "idle_timeout": 0, "cookie": 1524372928, "flags": 0, "length": 96, "table_id": 7, "match": {"dl_dst": "01:80:c2:00:00:00/ff:ff:ff:00:00:00", "dl_vlan": "100"}}
{"priority": 9002, "hard_timeout": 0, "byte_count": 0, "duration_sec": 13, "actions": ["GROUP:100"], "duration_nsec": 2000000, "packet_count": 0, "idle_timeout": 0, "cookie": 1524372928, "flags": 0, "length": 96, "table_id": 7, "match": {"dl_dst": "01:00:5e:00:00:00/ff:ff:ff:00:00:00", "dl_vlan": "100"}}
{"priority": 9000, "hard_timeout": 0, "byte_count": 0, "duration_sec": 13, "actions": ["GROUP:4196"], "duration_nsec": 2000000, "packet_count": 0, "idle_timeout": 0, "cookie": 1524372928, "flags": 0, "length": 80, "table_id": 7, "match": {"dl_vlan": "100"}}
```

By adding `dl_dst` to the regex pattern I'm making sure that it matches only the flows using group 100. 