### PR TITLE
use flowremoved to re-learn hosts instead of hard_timeout

### DIFF
--- a/src/ryu_faucet/org/onfsdn/faucet/valve.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/valve.py
@@ -935,6 +935,11 @@ class Valve(object):
         ofmsgs.extend(self._learn_host(valves, dp_id, pkt_meta))
         return ofmsgs
 
+    def delete_host_from_vlan(self, eth_src, vlan_vid):
+        """Delete an host from VLAN"""
+        vlan = self.dp.vlans[vlan_vid]
+        return self.host_manager.delete_host_from_vlan(eth_src, vlan)
+
     def host_expire(self):
         """Expire hosts not recently re/learned.
 

--- a/src/ryu_faucet/org/onfsdn/faucet/valve_host.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/valve_host.py
@@ -140,8 +140,7 @@ class ValveHostManager(object):
                 self.eth_src_table, in_port=in_port,
                 vlan=vlan, eth_src=eth_src),
             priority=(self.host_priority - 1),
-            inst=[valve_of.goto_table(self.eth_dst_table)],
-            hard_timeout=learn_timeout))
+            inst=[valve_of.goto_table(self.eth_dst_table)]))
 
         # update datapath to output packets to this mac via the associated port
         ofmsgs.append(self.valve_flowmod(

--- a/src/ryu_faucet/org/onfsdn/faucet/valve_of.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/valve_of.py
@@ -287,7 +287,8 @@ def flowmod(cookie, command, table_id, priority, out_port, out_group,
         match=match_fields,
         instructions=inst,
         hard_timeout=hard_timeout,
-        idle_timeout=idle_timeout)
+        idle_timeout=idle_timeout,
+        flags=ofp.OFPFF_SEND_FLOW_REM)
 
 
 def group_act(group_id):


### PR DESCRIPTION
I propose to use OFFlowRemoved to expire and re-learn hosts instead of hard_timeout.
I experienced performance loss when on AT switches due to something wrong with the combination of (OUTPUT_CONTROLLER and GOTO_TABLE). Faucet can capture flowremoved events and removes expired rules.

This patch is for release V1_4_0