### PR TITLE
add jitter to rule timeout to avoid re-learning a bunch of host simultaneously.

### DIFF
--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -16,9 +16,11 @@
 # limitations under the License.
 
 import time
+import random
 
 import valve_of
 
+LEARN_JITTER = 10 # seconds
 
 class HostCacheEntry(object):
 
@@ -125,7 +127,8 @@ class ValveHostManager(object):
                     self.eth_src_table, vlan=vlan, eth_src=eth_src),
                 priority=(self.host_priority - 2)))
         else:
-            learn_timeout = self.learn_timeout
+            #Add a jitter to avoid whole bunch of hosts timeout simultaneously
+            learn_timeout = self.learn_timeout + random.randint(0,LEARN_JITTER)
             ofmsgs.extend(self.delete_host_from_vlan(eth_src, vlan))
 
         # Update datapath to no longer send packets from this mac to controller


### PR DESCRIPTION
To enable hard_timeout, add 'hard_timeout_enabled: True' to dp config.
This PR is to replace PR #485 