### PR TITLE
re-learning using flowremoved event

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -21,6 +21,7 @@ from acl import ACL
 
 import networkx
 
+MIN_TIMEOUT = 30 # seconds
 
 class DP(Conf):
     """Object to hold the configuration for a faucet controlled datapath."""
@@ -151,6 +152,7 @@ class DP(Conf):
             assert isinstance(port, Port)
         for acl in self.acls.values():
             assert isinstance(acl, ACL)
+        assert self.timeout >= MIN_TIMEOUT # pylint: disable=no-member
 
     def set_defaults(self):
         for key, value in self.defaults.items():

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -122,6 +122,8 @@ class DP(Conf):
         # Ask switch to rate limit packet pps.
         # TODO: Not supported by OVS in 2.7.0
         'packetin_pps': 0,
+        # Enable flowremoved ack feature in the datapath
+        'flowremoved': True
         }
 
     def __init__(self, _id, conf):

--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -395,8 +395,11 @@ class Faucet(app_manager.RyuApp):
         Args:
             ryu_event (ryu.controller.event.EventReplyBase): triggering event.
         """
-        for valve in self.valves.values():
-            valve.host_expire()
+        for dp_id, valve in self.valves.items():
+            flowmods = valve.host_expire()
+            if flowmods:
+                ryudp = self.dpset.get(dp_id)
+                self._send_flow_msgs(ryudp, flowmods)
 
     @set_ev_cls(ofp_event.EventOFPPacketIn, MAIN_DISPATCHER) # pylint: disable=no-member
     @kill_on_exception(exc_logname)

--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -559,6 +559,18 @@ class Faucet(app_manager.RyuApp):
 
         self._send_flow_msgs(ryu_dp, flowmods)
 
+    @set_ev_cls(ofp_event.EventOFPFlowRemoved, MAIN_DISPATCHER) #pylint: disable=no-member
+    @kill_on_exception(exc_logname)
+    def handler_flowremoved(self, ryu_event):
+        msg = ryu_event.msg
+        ryu_dp = msg.datapath
+        dp_id = ryu_dp.id
+        ofp = msg.datapath.ofproto
+        valve = self.valves[dp_id]
+        if (msg.reason == ofp.OFPRR_IDLE_TIMEOUT or
+                msg.reason == ofp.OFPRR_HARD_TIMEOUT):
+            valve.rcv_rule_timeout(msg.table_id, msg.match)
+
     def get_config(self):
         config = {}
         for valve in self.valves.values():

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 import time
+import random
 
 import valve_of
 
@@ -125,7 +126,8 @@ class ValveHostManager(object):
                     self.eth_src_table, vlan=vlan, eth_src=eth_src),
                 priority=(self.host_priority - 2)))
         else:
-            learn_timeout = self.learn_timeout
+            #Add a jitter to avoid whole bunch of hosts timeout simultaneously
+            learn_timeout = self.learn_timeout + random.randint(0,5)
             ofmsgs.extend(self.delete_host_from_vlan(eth_src, vlan))
 
         # Update datapath to no longer send packets from this mac to controller

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -20,22 +20,26 @@ import random
 
 import valve_of
 
+IDLE_TIMEOUT_MARGIN = 10 #seconds
 
 class HostCacheEntry(object):
 
-    def __init__(self, eth_src, port_num, edge, permanent, now):
+    def __init__(self, eth_src, port, edge, permanent, now,
+                 src_rule_expired=False):
         self.eth_src = eth_src
-        self.port_num = port_num
+        self.port = port
         self.edge = edge
         self.permanent = permanent
         self.cache_time = now
+        self.src_rule_expired = src_rule_expired
 
 
 class ValveHostManager(object):
 
     def __init__(self, logger, eth_src_table, eth_dst_table,
                  learn_timeout, low_priority, host_priority,
-                 valve_in_match, valve_flowmod, valve_flowdel, valve_flowdrop):
+                 valve_in_match, valve_flowmod, valve_flowdel, valve_flowdrop,
+                 use_hard_timeout):
         self.logger = logger
         self.eth_src_table = eth_src_table
         self.eth_dst_table = eth_dst_table
@@ -46,6 +50,7 @@ class ValveHostManager(object):
         self.valve_flowmod = valve_flowmod
         self.valve_flowdel = valve_flowdel
         self.valve_flowdrop = valve_flowdrop
+        self.use_hard_timeout = use_hard_timeout
 
     def temp_ban_host_learning_on_vlan(self, vlan):
         return self.valve_flowdrop(
@@ -85,22 +90,44 @@ class ValveHostManager(object):
         return ofmsgs
 
     def expire_hosts_from_vlan(self, vlan, now):
+        ofmsgs = []
         expired_hosts = []
         for eth_src, host_cache_entry in vlan.host_cache.items():
             if not host_cache_entry.permanent:
                 host_cache_entry_age = now - host_cache_entry.cache_time
                 if host_cache_entry_age > self.learn_timeout:
-                    expired_hosts.append(eth_src)
+                    expired_hosts.append(host_cache_entry)
         if expired_hosts:
-            for eth_src in expired_hosts:
-                del vlan.host_cache[eth_src]
-                self.logger.info(
-                    'expiring host %s from vlan %u', eth_src, vlan.vid)
-            self.logger.info(
-                '%u recently active hosts on vlan %u',
-                len(vlan.host_cache), vlan.vid)
+            for host_cache_entry in expired_hosts:
+                if (not self.use_hard_timeout and
+                        not host_cache_entry.src_rule_expired):
+                    self.logger.info(
+                            'refreshing host %s from vlan %u',
+                            host_cache_entry.eth_src, vlan.vid)
+                    ofmsgs.extend(self.learn_host_on_vlan_port(
+                        host_cache_entry.port,
+                        vlan, host_cache_entry.eth_src,
+                        clear_old_rule=False))
+                else:
+                    eth_src = host_cache_entry.eth_src
+                    self._remove_expired_host_on_vlan(eth_src, vlan)
 
-    def learn_host_on_vlan_port(self, port, vlan, eth_src):
+        return ofmsgs
+
+    def expire_hosts_on_port(self, in_port, vlan):
+        for eth_src, host_cache_entry in list(vlan.host_cache.iteritems()):
+            if host_cache_entry.port.number == in_port:
+                self._remove_expired_host_on_vlan(eth_src, vlan)
+
+    def _remove_expired_host_on_vlan(self, eth_src, vlan):
+        del vlan.host_cache[eth_src]
+        self.logger.info(
+            'expiring host %s from vlan %u', eth_src, vlan.vid)
+        self.logger.info(
+            '%u recently active hosts on vlan %u',
+            len(vlan.host_cache), vlan.vid)
+
+    def learn_host_on_vlan_port(self, port, vlan, eth_src, clear_old_rule=True):
         now = time.time()
         in_port = port.number
         ofmsgs = []
@@ -110,14 +137,16 @@ class ValveHostManager(object):
         # if we detect a host moving rapidly between ports.
         if eth_src in vlan.host_cache:
             host_cache_entry = vlan.host_cache[eth_src]
-            if host_cache_entry.port_num == in_port:
+            if host_cache_entry.port.number == in_port:
                 cache_age = now - host_cache_entry.cache_time
                 if cache_age < 2:
                     return ofmsgs
 
         # hosts learned on this port never relearned
         if port.permanent_learn:
-            learn_timeout = 0
+            src_rule_hard_timeout = 0
+            src_rule_idle_timeout = 0
+            dst_rule_idle_timeout = 0
 
             # antispoof this host
             ofmsgs.append(self.valve_flowdrop(
@@ -126,19 +155,22 @@ class ValveHostManager(object):
                     self.eth_src_table, vlan=vlan, eth_src=eth_src),
                 priority=(self.host_priority - 2)))
         else:
-            #Add a jitter to avoid whole bunch of hosts timeout simultaneously
-            learn_timeout = self.learn_timeout + random.randint(0,5)
-            ofmsgs.extend(self.delete_host_from_vlan(eth_src, vlan))
-
-        # Update datapath to no longer send packets from this mac to controller
-        # note the use of hard_timeout here and idle_timeout for the dst table
-        # this is to ensure that the source rules will always be deleted before
-        # any rules on the dst table. Otherwise if the dst table rule expires
-        # but the src table rule is still being hit intermittantly the switch
-        # will flood packets to that dst and not realise it needs to relearn
-        # the rule
-        # NB: Must be lower than highest priority otherwise it can match
-        # flows destined to controller
+            if clear_old_rule:
+                ofmsgs.extend(self.delete_host_from_vlan(eth_src, vlan))
+            if self.use_hard_timeout:
+                #Add a jitter to avoid whole bunch of hosts timeout simultaneously
+                src_rule_idle_timeout = 0
+                dst_rule_idle_timeout = 0
+                src_rule_hard_timeout = self.learn_timeout + random.randint(0,5)
+            else:
+                src_rule_hard_timeout = 0
+                src_rule_idle_timeout = self.learn_timeout - IDLE_TIMEOUT_MARGIN
+                dst_rule_idle_timeout = self.learn_timeout + IDLE_TIMEOUT_MARGIN
+        # Idle_timeout is used for both src and dst table, with a longer timeout
+        # in dst table. When a host is disconnected, controller expects to see
+        # flowremoved event and it removes the host from cache.
+        # If not, it re-installs both src and st rules thus refreshing the timeouts.
+        # This is to make sure that dst rule always expires after src rule.
         ofmsgs.append(self.valve_flowmod(
             self.eth_src_table,
             self.valve_in_match(
@@ -146,7 +178,8 @@ class ValveHostManager(object):
                 vlan=vlan, eth_src=eth_src),
             priority=(self.host_priority - 1),
             inst=[valve_of.goto_table(self.eth_dst_table)],
-            hard_timeout=learn_timeout))
+            idle_timeout=src_rule_idle_timeout,
+            hard_timeout=src_rule_hard_timeout))
 
         # update datapath to output packets to this mac via the associated port
         ofmsgs.append(self.valve_flowmod(
@@ -155,11 +188,11 @@ class ValveHostManager(object):
                 self.eth_dst_table, vlan=vlan, eth_dst=eth_src),
             priority=self.host_priority,
             inst=self.build_port_out_inst(vlan, port),
-            idle_timeout=learn_timeout))
+            idle_timeout=dst_rule_idle_timeout))
 
         host_cache_entry = HostCacheEntry(
             eth_src,
-            in_port,
+            port,
             port.stack is None,
             port.permanent_learn,
             now)
@@ -169,3 +202,8 @@ class ValveHostManager(object):
             'learned %u hosts on vlan %u', len(vlan.host_cache), vlan.vid)
 
         return ofmsgs
+
+    def host_mark_src_rule_expired(self, in_port, vlan, eth_src):
+        host_cache_entry = vlan.host_cache[eth_src]
+        if host_cache_entry.port.number == in_port:
+            host_cache_entry.src_rule_expired = True

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -337,7 +337,7 @@ def build_match_dict(in_port=None, vlan=None,
 
 
 def flowmod(cookie, command, table_id, priority, out_port, out_group,
-            match_fields, inst, hard_timeout, idle_timeout):
+            match_fields, inst, hard_timeout, idle_timeout, flags=0):
     return parser.OFPFlowMod(
         datapath=None,
         cookie=cookie,
@@ -349,7 +349,8 @@ def flowmod(cookie, command, table_id, priority, out_port, out_group,
         match=match_fields,
         instructions=inst,
         hard_timeout=hard_timeout,
-        idle_timeout=idle_timeout)
+        idle_timeout=idle_timeout,
+        flags=flags)
 
 
 def group_act(group_id):


### PR DESCRIPTION
I verified this on AT switches and it works fine. This is enabled by default. Can be disabled by setting flowremoved: False under dp config. We can reduce unnecessary packet-ins when hard_timeout is used.
This is to replace the PR #486 