### PR TITLE
Python dependency netifaces requires GCC to be installed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM osrg/ryu
 RUN \
   apt-get update && \
   apt-get install -qy --no-install-recommends \
+    gcc \
     git \
     libpython2.7-dev \
     libyaml-dev \

--- a/Dockerfile.gauge
+++ b/Dockerfile.gauge
@@ -3,6 +3,7 @@ FROM osrg/ryu
 RUN \
   apt-get update && \
   apt-get install -qy --no-install-recommends \
+    gcc \
     git \
     libpython2.7-dev \
     libyaml-dev \

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -3,6 +3,7 @@ FROM osrg/ryu
 RUN \
   apt-get update && \
   apt-get install -qy --no-install-recommends \
+    gcc \
     git \
     influxdb \
     iputils-ping \


### PR DESCRIPTION
Fixes our Docker builds which are currently failing. 