### PR TITLE
Implement multiple VLAN header push support in ACLs.

### DIFF
--- a/faucet/valve_acl.py
+++ b/faucet/valve_acl.py
@@ -50,6 +50,11 @@ def build_acl_entry(rule_conf, acl_allow_inst, port_num=None, vlan_vid=None):
                 if 'vlan_vid' in output_dict:
                     output_actions.extend(
                         valve_of.push_vlan_act(output_dict['vlan_vid']))
+                # or, if a list, push them all (all with type Q).
+                elif 'vlan_vids' in output_dict:
+                    for vid in output_dict['vlan_vids']:
+                        output_actions.extend(
+                            valve_of.push_vlan_act(vid))
                 # output to port
                 port_no = output_dict['port']
                 output_actions.append(valve_of.output_port(port_no))

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -174,7 +174,7 @@ def set_vlan_vid(vlan_vid):
     return parser.OFPActionSetField(vlan_vid=vid_present(vlan_vid))
 
 
-def push_vlan_act(vlan_vid):
+def push_vlan_act(vlan_vid, eth_type=ether.ETH_TYPE_8021Q):
     """Return OpenFlow action list to push Ethernet 802.1Q header with VLAN VID.
 
     Args:
@@ -183,7 +183,7 @@ def push_vlan_act(vlan_vid):
         list: actions to push 802.1Q header with VLAN VID set.
     """
     return [
-        parser.OFPActionPushVlan(ether.ETH_TYPE_8021Q),
+        parser.OFPActionPushVlan(eth_type),
         set_vlan_vid(vlan_vid),
     ]
 

--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -1510,6 +1510,58 @@ acls:
             'vlan 123', tcpdump_txt))
 
 
+class FaucetUntaggedMultiVlansOutputTest(FaucetUntaggedTest):
+
+    CONFIG_GLOBAL = """
+vlans:
+    100:
+        description: "untagged"
+        unicast_flood: False
+acls:
+    1:
+        - rule:
+            dl_dst: "01:02:03:04:05:06"
+            actions:
+                output:
+                    dl_dst: "06:06:06:06:06:06"
+                    vlan_vids: [123, 456]
+                    port: acloutport
+"""
+
+    CONFIG = """
+        interfaces:
+            %(port_1)d:
+                native_vlan: 100
+                description: "b1"
+                acl_in: 1
+            acloutport:
+                number: %(port_2)d
+                native_vlan: 100
+                description: "b2"
+            %(port_3)d:
+                native_vlan: 100
+                description: "b3"
+            %(port_4)d:
+                native_vlan: 100
+                description: "b4"
+"""
+
+    @unittest.skip('needs OVS dev or > v2.8')
+    def test_untagged(self):
+        first_host, second_host = self.net.hosts[0:2]
+        # we expected to see the rewritten address and VLAN
+        tcpdump_filter = 'vlan'
+        tcpdump_txt = self.tcpdump_helper(
+            second_host, tcpdump_filter, [
+                lambda: first_host.cmd(
+                    'arp -s %s %s' % (second_host.IP(), '01:02:03:04:05:06')),
+                lambda: first_host.cmd('ping -c1 %s' % second_host.IP())])
+        self.assertTrue(re.search(
+            '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
+        self.assertTrue(re.search(
+            'vlan 456.+vlan 123', tcpdump_txt))
+
+
 class FaucetUntaggedMirrorTest(FaucetUntaggedTest):
 
     CONFIG_GLOBAL = """


### PR DESCRIPTION
        - rule:
            dl_dst: "01:02:03:04:05:06"
            actions:
                output:
                    dl_dst: "06:06:06:06:06:06"
                    vlan_vids: [123, 456]
                    port: acloutport

You can specify multiple VIDs, and they are pushed left to right.

Each header will have ether type 0x8100.

Requires OVS dev + https://github.com/openvswitch/ovs/commit/f0fb825a3785320430686834741c718ff4f8ebf4.