### PR TITLE
a fix for permanent learning port fails to learn when reloading config

### DIFF
--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -662,12 +662,13 @@ class Valve(object):
                 port, vlan, self._find_forwarding_table(vlan), mirror_act))
         return ofmsgs
 
-    def port_add(self, dp_id, port_num, modify=False):
+    def port_add(self, dp_id, port_num, modify=False, old_eth_srcs=[]):
         """Handle the addition of a port.
 
         Args:
             dp_id (int): datapath ID.
             port_num (int): port number.
+            old_eth_srcs (list): eth MAC of antisproofing hosts
         Returns:
             list: OpenFlow messages, if any.
         """
@@ -684,8 +685,14 @@ class Valve(object):
 
         ofmsgs = []
         if modify:
-            if not port.permanent_learn:
-                # delete eth_dst rules
+            if port.permanent_learn:
+                # delete antisproofing flows
+                for eth_src in old_eth_srcs:
+                    ofmsgs.extend(self.valve_flowdel(
+                        self.dp.eth_src_table,
+                        match=self.valve_in_match(
+                            self.dp.eth_src_table, eth_src=eth_src)))
+            else:
                 ofmsgs.extend(self.valve_flowdel(
                     self.dp.eth_dst_table,
                     out_port=port_num))
@@ -731,12 +738,13 @@ class Valve(object):
             ofmsgs.extend(self._port_add_vlans(port, mirror_act))
         return ofmsgs
 
-    def port_delete(self, dp_id, port_num):
+    def port_delete(self, dp_id, port_num, old_eth_srcs=[]):
         """Handle the deletion of a port.
 
         Args:
             dp_id (int): datapath ID.
             port_num (int): port number.
+            old_eth_srcs (list): list of MAC learned on this port
         Returns:
             list: OpenFlow messages, if any.
         """
@@ -753,14 +761,19 @@ class Valve(object):
 
         ofmsgs = []
 
-        if not port.permanent_learn:
+        if port.permanent_learn:
+            # delete antisproofing flows
+            for eth_src in old_eth_srcs:
+                ofmsgs.extend(self.valve_flowdel(
+                    self.dp.eth_src_table,
+                    match=self.valve_in_match(
+                        self.dp.eth_src_table, eth_src=eth_src)))
+        else:
             ofmsgs.extend(self._delete_all_port_match_flows(port))
-
             # delete eth_dst rules
             ofmsgs.extend(self.valve_flowdel(
                 self.dp.eth_dst_table,
                 out_port=port_num))
-
         for vlan in list(self.dp.vlans.values()):
             if port in vlan.get_ports():
                 ofmsgs.extend(self.flood_manager.build_flood_rules(
@@ -979,6 +992,20 @@ class Valve(object):
         for vlan in list(self.dp.vlans.values()):
             self.host_manager.expire_hosts_from_vlan(vlan, now)
 
+
+    def _get_eth_srcs_learned_on_port(self, dp, port_no):
+        old_eth_srcs = []
+        if port_no in dp.ports:
+            port = dp.ports[port_no]
+            for vid in [port.native_vlan] + port.tagged_vlans:
+                if vid is None:
+                    continue
+                vlan = dp.vlans[vid]
+                for eth_src, host_cache_entry in list(vlan.host_cache.items()):
+                    if host_cache_entry.port_num == port_no:
+                        old_eth_srcs.append(eth_src)
+        return old_eth_srcs
+
     def _get_config_changes(self, new_dp):
         """Detect any config changes.
 
@@ -1021,14 +1048,13 @@ class Valve(object):
         for vid, new_vlan in list(new_dp.vlans.items()):
             if vid not in self.dp.vlans or new_vlan != self.dp.vlans[vid]:
                 changed_vlans.add(vid)
-            for port in new_vlan.get_ports():
-                changed_ports.add(port.number)
+                for port in new_vlan.get_ports():
+                    changed_ports.add(port.number)
 
         deleted_ports = set([])
         for port_no in list(self.dp.ports.keys()):
             if port_no not in new_dp.ports:
                 deleted_ports.add(port_no)
-
         changes = (deleted_ports, changed_ports, deleted_vlans, changed_vlans)
         return changes
 
@@ -1047,16 +1073,19 @@ class Valve(object):
         """
         deleted_ports, changed_ports, deleted_vlans, changed_vlans = changes
         ofmsgs = []
+        old_dp = self.dp
         for port_no in deleted_ports:
             self.logger.info('ports deleted: %s', deleted_ports)
-            ofmsgs.extend(self.port_delete(self.dp.dp_id, port_no))
+            old_eth_srcs = self._get_eth_srcs_learned_on_port(old_dp, port_no)
+            ofmsgs.extend(self.port_delete(self.dp.dp_id, port_no, old_eth_srcs))
         for vid in deleted_vlans:
             self.logger.info('VLANs deleted: %s', deleted_vlans)
             vlan = self.dp.vlans[vid]
             ofmsgs.extend(self._del_vlan(vlan))
         for vid in changed_vlans:
-            vlan = self.dp.vlans[vid]
-            ofmsgs.extend(self._del_vlan(vlan))
+            if vid in self.dp.vlans:
+                vlan = self.dp.vlans[vid]
+                ofmsgs.extend(self._del_vlan(vlan))
 
         self.dp = new_dp
         self.dp.running = True
@@ -1066,8 +1095,9 @@ class Valve(object):
             vlan = self.dp.vlans[vid]
             ofmsgs.extend(self._add_vlan(vlan, set()))
         for port_no in changed_ports:
-            self.logger.info('ports changed/added: %s', changed_ports)
-            ofmsgs.extend(self.port_add(self.dp.dp_id, port_no, True))
+            self.logger.info('ports changed/added: %s', port_no)
+            old_eth_srcs = self._get_eth_srcs_learned_on_port(old_dp, port_no)
+            ofmsgs.extend(self.port_add(self.dp.dp_id, port_no, True, old_eth_srcs))
         return ofmsgs
 
     def reload_config(self, new_dp):

--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -468,7 +468,7 @@ vlans:
 
 
 class FaucetSanityTest(FaucetUntaggedTest):
-    """Sanity test - make sure test environment is correct before running all tess.""" 
+    """Sanity test - make sure test environment is correct before running all tess."""
 
     pass
 
@@ -771,31 +771,22 @@ class FaucetUntaggedHUPTest(FaucetUntaggedTest):
             self.ping_all_when_learned()
 
 
-class FaucetUntaggedHUPConfigChangeTest(FaucetUntaggedTest):
+class FaucetConfigReloadTest(FaucetTest):
     """Test handling HUP signal with config change."""
 
+    N_UNTAGGED = 4
+    N_TAGGED = 0
     CONFIG_GLOBAL = """
 vlans:
     100:
         description: "untagged"
-acls:
-    1:
-        - rule:
-            dl_type: 0x800
-            nw_proto: 6
-            tp_dst: 53
-            actions:
-                allow: 0
-        - rule:
-            actions:
-                allow: 1
+
 """
     CONFIG = """
         interfaces:
             %(port_1)d:
                 native_vlan: 100
                 description: "b1"
-                acl_in: 1
             %(port_2)d:
                 native_vlan: 100
                 description: "b2"
@@ -806,75 +797,107 @@ acls:
                 native_vlan: 100
                 description: "b4"
 """
+    ACL = """
+acls:
+    1:
+        - rule:
+            dl_type: 0x800
+            nw_proto: 6
+            tp_dst: 5001
+            actions:
+                allow: 0
+        - rule:
+            dl_type: 0x800
+            nw_proto: 6
+            tp_dst: 5002
+            actions:
+                allow: 1
+        - rule:
+            actions:
+                allow: 1
+    2:
+        - rule:
+            dl_type: 0x800
+            nw_proto: 6
+            tp_dst: 5001
+            actions:
+                allow: 1
+        - rule:
+            dl_type: 0x800
+            nw_proto: 6
+            tp_dst: 5002
+            actions:
+                allow: 0
+        - rule:
+            actions:
+                allow: 1
+"""
+    def setUp(self):
+        super(FaucetConfigReloadTest, self).setUp()
+        self.acl_config_file = '%s/acl.yaml' % self.tmpdir
+        open(self.acl_config_file, 'w').write(self.ACL)
+        open(os.environ['FAUCET_CONFIG'], 'a').write(
+                'include:\n     - %s' % self.acl_config_file)
+        self.topo = self.topo_class(
+            self.ports_sock, dpid=self.dpid,
+            n_tagged=self.N_TAGGED, n_untagged=self.N_UNTAGGED)
+        self.start_net()
 
-    def ntest_change_port_vlan(self):
-        self.ping_all_when_learned()
-        conf = yaml.load(self.CONFIG)
-        vid = 100
-        for _ in range(1, 2):
-            time.sleep(2)
-            flow_p1 = self.get_matching_flow_on_dpid(
-                self.dpid,
-                ('"table_id": 1, "match": '
-                 '{"dl_vlan": "0x0000", "in_port": %(port_1)d}' % self.port_map))
-            flow_p3 = self.get_matching_flow_on_dpid(
-                self.dpid,
-                ('"table_id": 1, "match": '
-                 '{"dl_vlan": "0x0000", "in_port": %(port_3)d}' % self.port_map))
-            prev_dur_p1 = flow_p1['duration_sec']
-            prev_dur_p3 = flow_p3['duration_sec']
-            if vid == 200:
-                vid = 100
-                ping_test = self.ping_all_when_learned
-            else:
-                vid = 200
-                ping_test = self.ping_cross_vlans
-            conf['dps']['faucet-1']['interfaces'][1]['native_vlan'] = vid
-            conf['dps']['faucet-1']['interfaces'][2]['native_vlan'] = vid
-            open(os.environ['FAUCET_CONFIG'], 'w').write(yaml.dump(conf))
+    def get_port_match_flow(self, port_no, table_id=3):
+        exp_flow = '"table_id: %d".+"in_port": %s' % (table_id, port_no)
+        flow = self.get_matching_flow_on_dpid(self.dpid, exp_flow)
+        return flow
+
+    def change_port_config(self, port, config_name, config_value, restart=True):
+        conf = yaml.load(open(os.environ['FAUCET_CONFIG'], 'r').read())
+        conf['dps']['faucet-1']['interfaces'][port][config_name] = config_value
+        open(os.environ['FAUCET_CONFIG'], 'w').write(yaml.dump(conf))
+        if restart:
             self.hup_faucet()
-            flow_p1 = self.get_matching_flow_on_dpid(
-                self.dpid,
-                ('"table_id": 1, "match": '
-                 '{"dl_vlan": "0x0000", "in_port": %(port_1)d}' % self.port_map))
-            flow_p3 = self.get_matching_flow_on_dpid(
-                self.dpid,
-                ('"table_id": 1, "match": '
-                 '{"dl_vlan": "0x0000", "in_port": %(port_3)d}' % self.port_map))
-            actions = flow_p1.get('actions', '')
-            actions = [act for act in actions if 'vlan_vid' in act]
-            vid_ = re.findall(r'\d+', str(actions))
-            self.assertEqual(vid+4096, int(vid_[0]))
-            dur_p1 = flow_p1['duration_sec']
-            dur_p3 = flow_p3['duration_sec']
-            self.assertGreater(prev_dur_p1, dur_p1)
-            self.assertLess(prev_dur_p3, dur_p3)
-            ping_test()
 
-    def ping_cross_vlans(self):
-        self.assertEqual(0,
-                         self.net.ping((self.net.hosts[0], self.net.hosts[1])))
-        self.assertEqual(0,
-                         self.net.ping((self.net.hosts[2], self.net.hosts[3])))
-        self.assertEqual(100,
-                         self.net.ping((self.net.hosts[0], self.net.hosts[3])))
-
-    def test_change_port_acl(self):
-        self.ping_all_when_learned()
-        conf = yaml.load(self.CONFIG)
-        for i in range(1, 2):
-            time.sleep(2)
-            conf['acls'][1].insert(
-                0,
-                {'rule': {'dl_type': 0x800,
-                          'nw_proto': 17,
-                          'tp_dst': 8000+i,
-                          'actions': {'allow': 1}}})
-            open(os.environ['FAUCET_CONFIG'], 'w').write(yaml.dump(conf))
+    def change_vlan_config(self, vlan, config_name, config_value, restart=True):
+        conf = yaml.load(open(os.environ['FAUCET_CONFIG'], 'r').read())
+        conf['vlans'][vlan][config_name] = config_value
+        open(os.environ['FAUCET_CONFIG'], 'w').write(yaml.dump(conf))
+        if restart:
             self.hup_faucet()
-            self.wait_until_matching_flow(
-                ('{"dl_type": 2048, "nw_proto": 17,'
-                 ' "in_port": %d, "tp_dst": %d}' % (self.port_map["port_1"], 8000+i)))
+
+    def test_port_change_vlan(self):
+        first_host = self.net.hosts[0]
+        second_host = self.net.hosts[1]
+        self.ping_all_when_learned()
+        self.change_port_config(1, 'native_vlan', 200, restart=False)
+        self.change_port_config(2, 'native_vlan', 200, restart=True)
+        self.wait_until_matching_flow(
+                r'SET_FIELD: {vlan_vid:4296}.+in_port": 1',
+                timeout=2)
+        self.one_ipv4_ping(first_host, second_host.IP(), require_host_learned=False)
+
+    def test_port_change_acl(self):
+        self.ping_all_when_learned()
+        self.change_port_config(1, 'acl_in', 1)
+        self.wait_until_matching_flow(
+                r'"actions": \[\].+"in_port": 1, "tp_dst": 5001')
+        first_host, second_host = self.net.hosts[0:2]
+        self.ping_all_when_learned()
+        self.verify_tp_dst_blocked(5001, first_host, second_host)
+        self.verify_tp_dst_notblocked(5002, first_host, second_host)
+
+    def test_port_change_permanent_learn(self):
+        first_host, second_host, third_host = self.net.hosts[0:3]
+        self.change_port_config(1, 'permanent_learn', True)
+        self.ping_all_when_learned()
+        original_third_host_mac = third_host.MAC()
+        third_host.setMAC(first_host.MAC())
+        self.assertEqual(100.0, self.net.ping((second_host, third_host)))
+        self.assertEqual(0, self.net.ping((first_host, second_host)))
+        third_host.setMAC(original_third_host_mac)
+        self.ping_all_when_learned()
+        self.change_port_config(1, 'acl_in', 1)
+        self.wait_until_matching_flow(
+                r'"actions": \[\].+"in_port": 1, "tp_dst": 5001')
+        self.verify_tp_dst_blocked(5001, first_host, second_host)
+        self.verify_tp_dst_notblocked(5002, first_host, second_host)
 
 
 class FaucetSingleUntaggedBGPIPv4RouteTest(FaucetUntaggedTest):


### PR DESCRIPTION
Reopen for #527. 
I could not replicate the error appeared on #531. But the reason could be the lack of delay for Faucet to finish the flow installation. I added time.sleep after the hup_faucet, hope this will fix it.