### PR TITLE
Use py2 and py3 compatible io.read() instead of read().

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 
+import io
 import os
 import re
 
 from setuptools import setup
 
 setup_dir = os.path.dirname(__file__)
-readme_contents = open(os.path.join(setup_dir, 'README.rst')).read()
+readme_contents = io.open(os.path.join(setup_dir, 'README.rst'), encoding="utf-8").read()
 faucet_version = re.match(r'.+version: ([0-9\.]+)', readme_contents).group(1)
 os.environ["PBR_VERSION"] = faucet_version
 


### PR DESCRIPTION
Fix faucet setup.py for issue #497 