### PR TITLE
Destination MAC rewrite

### DIFF
--- a/faucet/valve_acl.py
+++ b/faucet/valve_acl.py
@@ -64,6 +64,10 @@ def build_acl_entry(rule_conf, acl_allow_inst, port_num=None, vlan_vid=None):
                 output_actions.append(valve_of.output_port(port_no))
                 acl_inst.append(valve_of.apply_actions(output_actions))
                 continue
+
+            if 'dl_dst' in attrib_value:
+                acl_inst.append(valve_of.apply_actions([valve_of.set_eth_dst(attrib_value["dl_dst"])]))
+
             if allow:
                 acl_inst.append(acl_allow_inst)
         else:

--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -2767,6 +2767,111 @@ vlans:
             with_group_table=True)
 
 
+class FaucetDestRewriteTest(FaucetUntaggedTest):
+    CONFIG_GLOBAL = """
+vlans:
+    100:
+        description: "untagged"
+
+acls:
+    1:
+        - rule:
+            dl_dst: "00:00:00:00:00:02"
+            actions:
+                allow: 1
+                dl_dst: "00:00:00:00:00:03"
+        - rule:
+            actions:
+                allow: 1
+"""
+    CONFIG = """
+        interfaces:
+            %(port_1)d:
+                native_vlan: 100
+                description: "b1"
+                acl_in: 1
+            %(port_2)d:
+                native_vlan: 100
+                description: "b2"
+            %(port_3)d:
+                native_vlan: 100
+                decsciption: "b3"
+""" 
+
+    def test_untagged(self):
+        first_host, second_host = self.net.hosts[0:2]
+        # we expect to see the rewritten mac address.
+        tcpdump_filter = ('icmp and ether dst 00:00:00:00:00:03')
+        tcpdump_txt = self.tcpdump_helper(
+            second_host, tcpdump_filter, [
+                lambda: first_host.cmd(
+                    'arp -s %s %s' % (second_host.IP(), '00:00:00:00:00:02')),
+                lambda: first_host.cmd('ping -c1 %s' % second_host.IP())])
+        print(tcpdump_txt)
+        self.assertTrue(re.search(
+            '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
+
+    def test_switching(self):
+        """Tests that a acl can rewrite the destination mac address,
+            and the packet will only go out the port of the new mac.
+            (Continues through faucet pipeline)
+        """
+        first_host, second_host, third_host = self.net.hosts[0:3]
+        
+        second_host.setMAC("00:00:00:00:00:02")
+        third_host.setMAC("00:00:00:00:00:03")
+        # get the switch to port/mac learn a host.
+
+        # let h1 think h3 is @ h2.mac, the acl should change the dst mac, 
+        #  so that h3 will receive it and reply.
+        third_host.cmd("arp -s %s %s" %(second_host.IP(), second_host.MAC()))
+        third_host.cmd("ping -c1 %s" % second_host.IP())
+        
+        tcpdump_filter = ("icmp and ether src %s and ether dst %s" % (first_host.MAC(), third_host.MAC()))
+        tcpdump_txt = self.tcpdump_helper(
+            second_host, tcpdump_filter, [
+                lambda: first_host.cmd(
+                    "arp -s %s %s" % (third_host.IP(), second_host.MAC())),
+                # this will fail if no reply
+                lambda: self.one_ipv4_ping(first_host, third_host.IP(), require_host_learned=False)])
+
+        # ping from h1 to h2.mac should appear in third host, and not second host, as 
+        # the acl should rewrite the dst mac.
+        self.assertFalse(re.search(
+            "%s: ICMP echo request" % third_host.IP(), tcpdump_txt))
+
+    def test_switching1(self):
+        """Same as test_switching(), except changed what host the tcpdump is done on.
+            Quick check until make tcpdump_helper (or similar) do multiple interfaces.
+           Tests that a acl can rewrite the destination mac address,
+            and the packet will only go out the port of the new mac.
+            (Continues through faucet pipeline)
+        """
+        first_host, second_host, third_host = self.net.hosts[0:3]
+        
+        second_host.setMAC("00:00:00:00:00:02")
+        third_host.setMAC("00:00:00:00:00:03")
+        # get the switch to port/mac learn a host.
+ 
+        # let h1 think h3 is @ h2.mac, the acl should change the dst mac, 
+        #  so that h3 will receive it and reply.      
+        third_host.cmd("arp -s %s %s" %(second_host.IP(), second_host.MAC()))
+        third_host.cmd("ping -c1 %s" % second_host.IP())
+
+        tcpdump_filter = ("icmp and ether src %s and ether dst %s" % (first_host.MAC(), third_host.MAC()))
+        tcpdump_txt = self.tcpdump_helper(
+            third_host, tcpdump_filter, [
+                lambda: first_host.cmd(
+                    "arp -s %s %s" % (third_host.IP(), second_host.MAC())),
+                # this will fail if no reply
+                lambda: self.one_ipv4_ping(first_host, third_host.IP(), require_host_learned=False)])
+
+        # ping from h1 to h2.mac should appear in third host, and not second host, as 
+        # the acl should rewrite the dst mac.
+        self.assertTrue(re.search(
+            "%s: ICMP echo request" % third_host.IP(), tcpdump_txt))
+
+
 def import_hw_config():
     """Import configuration for physical switch testing."""
     try:

--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -2807,7 +2807,6 @@ acls:
                 lambda: first_host.cmd(
                     'arp -s %s %s' % (second_host.IP(), '00:00:00:00:00:02')),
                 lambda: first_host.cmd('ping -c1 %s' % second_host.IP())])
-        print(tcpdump_txt)
         self.assertTrue(re.search(
             '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
 
@@ -2826,15 +2825,15 @@ acls:
         #  so that h3 will receive it and reply.
         third_host.cmd("arp -s %s %s" %(second_host.IP(), second_host.MAC()))
         third_host.cmd("ping -c1 %s" % second_host.IP())
-        
+        # if we don't sleep , the switch may not have installed the mac learned rules
+        time.sleep(2)
         tcpdump_filter = ("icmp and ether src %s and ether dst %s" % (first_host.MAC(), third_host.MAC()))
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(
                     "arp -s %s %s" % (third_host.IP(), second_host.MAC())),
                 # this will fail if no reply
-                lambda: self.one_ipv4_ping(first_host, third_host.IP(), require_host_learned=False)])
-
+                lambda: self.one_ipv4_ping(first_host, third_host.IP(), require_host_learned=False)]) 
         # ping from h1 to h2.mac should appear in third host, and not second host, as 
         # the acl should rewrite the dst mac.
         self.assertFalse(re.search(
@@ -2857,7 +2856,8 @@ acls:
         #  so that h3 will receive it and reply.      
         third_host.cmd("arp -s %s %s" %(second_host.IP(), second_host.MAC()))
         third_host.cmd("ping -c1 %s" % second_host.IP())
-
+        # if we don't sleep , the switch may not have installed the mac learned rules
+        time.sleep(2)
         tcpdump_filter = ("icmp and ether src %s and ether dst %s" % (first_host.MAC(), third_host.MAC()))
         tcpdump_txt = self.tcpdump_helper(
             third_host, tcpdump_filter, [

--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -2825,8 +2825,10 @@ acls:
         #  so that h3 will receive it and reply.
         third_host.cmd("arp -s %s %s" %(second_host.IP(), second_host.MAC()))
         third_host.cmd("ping -c1 %s" % second_host.IP())
-        # if we don't sleep , the switch may not have installed the mac learned rules
-        time.sleep(2)
+
+        self.wait_until_matching_flow(
+            r'OUTPUT:3.+table_id": 6.+dl_dst": "00:00:00:00:00:03"',
+            timeout=2)
         tcpdump_filter = ("icmp and ether src %s and ether dst %s" % (first_host.MAC(), third_host.MAC()))
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
@@ -2856,8 +2858,10 @@ acls:
         #  so that h3 will receive it and reply.      
         third_host.cmd("arp -s %s %s" %(second_host.IP(), second_host.MAC()))
         third_host.cmd("ping -c1 %s" % second_host.IP())
-        # if we don't sleep , the switch may not have installed the mac learned rules
-        time.sleep(2)
+
+        self.wait_until_matching_flow(
+            r'OUTPUT:3.+table_id": 6.+dl_dst": "00:00:00:00:00:03"',
+            timeout=2)
         tcpdump_filter = ("icmp and ether src %s and ether dst %s" % (first_host.MAC(), third_host.MAC()))
         tcpdump_txt = self.tcpdump_helper(
             third_host, tcpdump_filter, [


### PR DESCRIPTION
Rewrites the destination MAC address, while still allowing the packet through the Faucet pipeline (to be switched based on the new MAC dest).
So an ACL can now look like:
```        
        - rule:
            dl_dst: "00:00:00:00:00:02"
            actions:
                allow: 1
                dl_dst: "00:00:00:00:00:03
```
