### PR TITLE
Work-around a PBR python3 bug.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,6 @@ license = Apache-2
 author = Faucet development team
 author-email = faucet-dev@list.waikato.ac.nz
 home-page = http://faucetsdn.org
-description-file = README.rst
 platform = any
 classifier =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
Having a installable faucet under pip3 is nicer than having a description-file.

Closes #497 