### PR TITLE
max_hosts for port

### DIFF
--- a/faucet/port.py
+++ b/faucet/port.py
@@ -29,6 +29,7 @@ class Port(Conf):
     tagged_vlans = []
     acl_in = None
     stack = {}
+    max_hosts = None
 
     defaults = {
         'number': None,
@@ -43,6 +44,7 @@ class Port(Conf):
         'tagged_vlans': None,
         'acl_in': None,
         'stack': None,
+        'max_hosts' : None,
         }
 
     def __init__(self, _id, conf=None):

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -911,6 +911,13 @@ class Valve(object):
         return PacketMeta(pkt, eth_pkt, port, vlan, eth_src, eth_dst)
 
     def _port_learn_ban_rules(self, pkt_meta):
+        """Limit learning to a maximum configured on this port.
+
+        Args:
+            pkt_meta: PacketMeta instance.
+        Returns:
+            list: OpenFlow messages, if any.
+        """
         ofmsgs = []
 
         port = pkt_meta.port

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -48,6 +48,13 @@ class ValveHostManager(object):
         self.valve_flowdel = valve_flowdel
         self.valve_flowdrop = valve_flowdrop
 
+    def temp_ban_host_learning_on_port(self, port): 
+        return self.valve_flowdrop(
+            self.eth_src_table,
+            self.valve_in_match(self.eth_src_table, in_port=port.number),
+            priority=(self.low_priority + 1),
+            hard_timeout=self.host_priority)
+
     def temp_ban_host_learning_on_vlan(self, vlan):
         return self.valve_flowdrop(
             self.eth_src_table,

--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -805,7 +805,7 @@ vlans:
         flows = self.get_all_flows_from_dpid(self.dpid)
 
         # There are mac address being learnt that are not belonging to the hosts
-        # that are conneted to sw2, which is why the ping may not have 3 successful pings
+        # that are connected to sw2, which is why the ping may not have 3 successful pings
         # to the hosts connected to sw1, and therefore we cannot check if the hosts are learned or
         # not, as done in FaucetUntaggedMaxHostsTest.
         #  So check there are 3 learnt mac addresses in table 3.

--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -782,7 +782,7 @@ vlans:
             new_hosts.append(self.topo.addHost('nh%s' % h))
 
         sw1 = self.topo.switches()[0]
-        sw2 = self.topo.addSwitch(name="switch2", cls=OVSBridge)
+        sw2 = self.topo.addSwitch(name='switch2', cls=OVSBridge)
 
         self.topo.addLink(sw2, sw1, 1, 4)
         for h in new_hosts:
@@ -794,9 +794,9 @@ vlans:
         ping_hosts = []
         flag = True
         for h in self.net.hosts:
-            if h.name.startswith("nh"):
+            if h.name.startswith('nh'):
                 ping_hosts.append(h)
-            elif flag and h.name.startswith("u"):
+            elif flag and h.name.startswith('u'):
                 ping_hosts.append(h)
                 flag = False
 

--- a/tests/faucet_mininet_test.py
+++ b/tests/faucet_mininet_test.py
@@ -743,6 +743,7 @@ vlans:
         self.assertEquals(2, int(self.scrape_prometheus_var(
             r'vlan_hosts_learned\S+vlan="100"\S+')))
 
+
 class FaucetMaxHostsPortTest(FaucetTest):
     N_UNTAGGED = 3
     N_TAGGED = 0

--- a/tests/faucet_mininet_test_base.py
+++ b/tests/faucet_mininet_test_base.py
@@ -452,10 +452,6 @@ dbs:
         return self.matching_flow_present(
             '"table_id": 3,.+"dl_src": "%s"' % host.MAC(), timeout)
 
-    def host_learned_on_port(self, host, port_no, timeout=10):
-        return self.matching_flow_present(
-            '"table_id": 3,.+"dl_src": "%s", "in_port": %d' % (host.MAC(), port_no), timeout)
-
     def host_ipv4(self, host):
         """Return first IPv4/netmask for host's default interface."""
         host_ip_cmd = (

--- a/tests/faucet_mininet_test_base.py
+++ b/tests/faucet_mininet_test_base.py
@@ -452,6 +452,10 @@ dbs:
         return self.matching_flow_present(
             '"table_id": 3,.+"dl_src": "%s"' % host.MAC(), timeout)
 
+    def host_learned_on_port(self, host, port_no, timeout=10):
+        return self.matching_flow_present(
+            '"table_id": 3,.+"dl_src": "%s", "in_port": %d' % (host.MAC(), port_no), timeout)
+
     def host_ipv4(self, host):
         """Return first IPv4/netmask for host's default interface."""
         host_ip_cmd = (


### PR DESCRIPTION
Limits the number of hosts that can be learnt on a port at one time. Should behave in a similar way to VLAN max_hosts.

new config option
```yaml
      interfaces:
            4:
                native_vlan: 100
                description: "b4"
                max_hosts: 3
```