### PR TITLE
We no longer support python2. We are fully tested against python3.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ classifier =
     Topic :: System :: Networking
     Natural Language :: English
     Programming Language :: Python
-    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3.5
     Operating System :: Unix
 keywords =
     openflow


### PR DESCRIPTION
We no longer support python2. We are fully tested against python3.5 (and likely other versions of python3)