### PR TITLE
Eliminate hard-timeout, zero packet-ins

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -195,6 +195,7 @@ class DP(Conf):
         'advertise_interval': int,
         'proactive_learn': bool,
         'pipeline_config_dir': str,
+        'hard_timeout_enabled': bool,
     }
 
 

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -74,6 +74,7 @@ class DP(Conf):
     advertise_interval = None
     proactive_learn = None
     pipeline_config_dir = None
+    hard_timeout_enabled = None
 
     # Values that are set to None will be set using set_defaults
     # they are included here for testing and informational purposes
@@ -148,6 +149,8 @@ class DP(Conf):
         # whether proactive learning is enabled for IP nexthops
         'pipeline_config_dir': '/etc/ryu/faucet',
         # where config files for pipeline are stored (if any).
+        'hard_timeout_enabled': True,
+        #disable/enable hard timeout of rules
         }
 
     defaults_types = {

--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -269,8 +269,10 @@ class Faucet(app_manager.RyuApp):
     @kill_on_exception(exc_logname)
     def host_expire(self, _):
         """Handle a request expire host state in the controller."""
-        for valve in list(self.valves.values()):
-            valve.host_expire()
+        for dp_id, valve in list(self.valves.items()):
+            flowmods = valve.host_expire()
+            if flowmods:
+                self._send_flow_msgs(dp_id, flowmods)
             valve.update_metrics(self.metrics)
 
     @set_ev_cls(EventFaucetMetricUpdate, MAIN_DISPATCHER)
@@ -476,3 +478,15 @@ class Faucet(app_manager.RyuApp):
     def get_tables(self, dp_id):
         """FAUCET API: return config tables for one Valve."""
         return self.valves[dp_id].dp.get_tables()
+
+    @set_ev_cls(ofp_event.EventOFPFlowRemoved, MAIN_DISPATCHER) # pylint: disable=no-member
+    @kill_on_exception(exc_logname)
+    def handle_flowremoved(self, ryu_event):
+        msg = ryu_event.msg
+        ryu_dp = msg.datapath
+        ofp = msg.datapath.ofproto
+        reason = msg.reason
+        valve = self.valves[ryu_dp.id]
+        if reason == ofp.OFPRR_IDLE_TIMEOUT:
+            valve.flow_timeout(msg.table_id, msg.match)
+

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -128,7 +128,7 @@ class Valve(object):
             self.dp.timeout, self.dp.learn_jitter, self.dp.learn_ban_timeout,
             self.dp.low_priority, self.dp.highest_priority,
             self.valve_in_match, self.valve_flowmod, self.valve_flowdel,
-            self.valve_flowdrop)
+            self.valve_flowdrop, self.dp.hard_timeout_enabled)
 
     def dpid_log(self, log_msg):
         self.logger.info(
@@ -312,6 +312,7 @@ class Valve(object):
             priority = self.dp.lowest_priority
         if inst is None:
             inst = []
+        flags = 0 if self.dp.hard_timeout_enabled else ofp.OFPFF_SEND_FLOW_REM
         return valve_of.flowmod(
             self.dp.cookie,
             command,
@@ -322,7 +323,8 @@ class Valve(object):
             match,
             inst,
             hard_timeout,
-            idle_timeout)
+            idle_timeout,
+            flags)
 
     def valve_flowdel(self, table_id, match=None, priority=None,
                       out_port=ofp.OFPP_ANY, strict=False):
@@ -1053,7 +1055,7 @@ class Valve(object):
             # Repopulate MAC learning.
             hosts_on_port = {}
             for eth_src, host_cache_entry in sorted(list(vlan.host_cache.items())):
-                port_num = str(host_cache_entry.port_num)
+                port_num = str(host_cache_entry.port.number)
                 mac_int = int(eth_src.replace(':', ''), 16)
                 if port_num not in hosts_on_port:
                     hosts_on_port[port_num] = []
@@ -1120,11 +1122,14 @@ class Valve(object):
         Expire state from the host manager only; the switch does its own flow
         expiry.
         """
+        ofmsgs = []
         if not self.dp.running:
             return
         now = time.time()
         for vlan in list(self.dp.vlans.values()):
-            self.host_manager.expire_hosts_from_vlan(vlan, now)
+            ofmsgs.extend(self.host_manager.expire_hosts_from_vlan(vlan, now))
+
+        return ofmsgs
 
     def _get_eth_srcs_learned_on_port(self, dp, port_no):
         old_eth_srcs = []
@@ -1134,7 +1139,7 @@ class Valve(object):
                 if vlan is None:
                     continue
                 for eth_src, host_cache_entry in list(vlan.host_cache.items()):
-                    if host_cache_entry.port_num == port_no:
+                    if host_cache_entry.port.number == port_no:
                         old_eth_srcs.append(eth_src)
         return old_eth_srcs
 
@@ -1348,6 +1353,23 @@ class Valve(object):
             'vlans': vlans_dict,
             'acls': acls_dict,
             }
+
+    def flow_timeout(self, table_id, match):
+        eth_src = None
+        match_oxm_fields = match.to_jsondict()['OFPMatch']['oxm_fields']
+        if table_id == self.dp.eth_src_table:
+            for field in match_oxm_fields:
+                if isinstance(field, dict):
+                    value = field['OXMTlv']
+                    if value['field'] == 'eth_src':
+                        eth_src = value['value']
+                    if value['field'] == 'vlan_vid':
+                        vid = value['value'] & ~ofp.OFPVID_PRESENT
+                    if value['field'] == 'in_port':
+                        in_port = value['value']
+            if eth_src and vid and in_port:
+                vlan = self.dp.vlans[vid]
+                self.host_manager.src_rule_expire(vlan, in_port, eth_src)
 
 
 class TfmValve(Valve):

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -28,19 +28,21 @@ except ImportError:
 
 class HostCacheEntry(object):
 
-    def __init__(self, eth_src, port_num, edge, permanent, now):
+    def __init__(self, eth_src, port, edge, permanent, now, expired=False):
         self.eth_src = eth_src
-        self.port_num = port_num
+        self.port = port
         self.edge = edge
         self.permanent = permanent
         self.cache_time = now
+        self.expired = expired
 
 
 class ValveHostManager(object):
 
     def __init__(self, logger, eth_src_table, eth_dst_table,
                  learn_timeout, learn_jitter, learn_ban_timeout, low_priority, host_priority,
-                 valve_in_match, valve_flowmod, valve_flowdel, valve_flowdrop):
+                 valve_in_match, valve_flowmod, valve_flowdel, valve_flowdrop,
+                 hard_timeout_enabled):
         self.logger = logger
         self.eth_src_table = eth_src_table
         self.eth_dst_table = eth_dst_table
@@ -53,6 +55,7 @@ class ValveHostManager(object):
         self.valve_flowmod = valve_flowmod
         self.valve_flowdel = valve_flowdel
         self.valve_flowdrop = valve_flowdrop
+        self.hard_timeout_enabled = hard_timeout_enabled
 
     def temp_ban_host_learning_on_port(self, port):
         return self.valve_flowdrop(
@@ -101,12 +104,19 @@ class ValveHostManager(object):
         return ofmsgs
 
     def expire_hosts_from_vlan(self, vlan, now):
+        ofmsgs = []
         expired_hosts = []
         for eth_src, host_cache_entry in list(vlan.host_cache.items()):
             if not host_cache_entry.permanent:
                 host_cache_entry_age = now - host_cache_entry.cache_time
                 if host_cache_entry_age > self.learn_timeout:
-                    expired_hosts.append(eth_src)
+                    if self.hard_timeout_enabled or host_cache_entry.expired:
+                        expired_hosts.append(eth_src)
+                    else:
+                        self.logger.info(
+                            'refreshing host %s from vlan %u', eth_src, vlan.vid)
+                        ofmsgs.extend(self.learn_host_on_vlan_port(
+                            host_cache_entry.port, vlan, eth_src, False))
         if expired_hosts:
             for eth_src in expired_hosts:
                 del vlan.host_cache[eth_src]
@@ -116,10 +126,12 @@ class ValveHostManager(object):
                 '%u recently active hosts on vlan %u',
                 self.hosts_learned_on_vlan_count(vlan), vlan.vid)
 
+        return ofmsgs
+
     def hosts_learned_on_vlan_count(self, vlan):
         return len(vlan.host_cache)
 
-    def learn_host_on_vlan_port(self, port, vlan, eth_src):
+    def learn_host_on_vlan_port(self, port, vlan, eth_src, clear=True):
         now = time.time()
         in_port = port.number
         ofmsgs = []
@@ -129,7 +141,7 @@ class ValveHostManager(object):
         # if we detect a host moving rapidly between ports.
         if eth_src in vlan.host_cache:
             host_cache_entry = vlan.host_cache[eth_src]
-            if host_cache_entry.port_num == in_port:
+            if host_cache_entry.port.number == in_port:
                 cache_age = now - host_cache_entry.cache_time
                 if cache_age < 2:
                     return ofmsgs
@@ -149,7 +161,8 @@ class ValveHostManager(object):
             learn_timeout = int(max(abs(
                 self.learn_timeout -
                 (self.learn_jitter / 2) + random.randint(0, self.learn_jitter)), 2))
-            ofmsgs.extend(self.delete_host_from_vlan(eth_src, vlan))
+            if clear:
+                ofmsgs.extend(self.delete_host_from_vlan(eth_src, vlan))
 
         # Update datapath to no longer send packets from this mac to controller
         # note the use of hard_timeout here and idle_timeout for the dst table
@@ -160,6 +173,15 @@ class ValveHostManager(object):
         # the rule
         # NB: Must be lower than highest priority otherwise it can match
         # flows destined to controller
+        if self.hard_timeout_enabled:
+            src_rule_idle_timeout = 0
+            src_rule_hard_timeout = learn_timeout
+            dst_rule_idle_timeout = learn_timeout
+        else:
+            src_rule_idle_timeout = learn_timeout
+            src_rule_hard_timeout = 0
+            dst_rule_idle_timeout = learn_timeout
+
         ofmsgs.append(self.valve_flowmod(
             self.eth_src_table,
             self.valve_in_match(
@@ -167,7 +189,8 @@ class ValveHostManager(object):
                 vlan=vlan, eth_src=eth_src),
             priority=(self.host_priority - 1),
             inst=[valve_of.goto_table(self.eth_dst_table)],
-            hard_timeout=learn_timeout))
+            hard_timeout=src_rule_hard_timeout,
+            idle_timeout=src_rule_idle_timeout))
 
         # update datapath to output packets to this mac via the associated port
         ofmsgs.append(self.valve_flowmod(
@@ -176,7 +199,7 @@ class ValveHostManager(object):
                 self.eth_dst_table, vlan=vlan, eth_dst=eth_src),
             priority=self.host_priority,
             inst=self.build_port_out_inst(vlan, port),
-            idle_timeout=learn_timeout))
+            idle_timeout=dst_rule_idle_timeout))
 
         if port.hairpin:
             ofmsgs.append(self.valve_flowmod(
@@ -189,7 +212,7 @@ class ValveHostManager(object):
 
         host_cache_entry = HostCacheEntry(
             eth_src,
-            in_port,
+            port,
             port.stack is None,
             port.permanent_learn,
             now)
@@ -201,3 +224,9 @@ class ValveHostManager(object):
             vlan.vid)
 
         return ofmsgs
+
+    def src_rule_expire(self, vlan, in_port, eth_src):
+        if eth_src in vlan.host_cache:
+            host_cache_entry = vlan.host_cache[eth_src]
+            if host_cache_entry.port.number == in_port:
+                host_cache_entry.expired = True

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -339,7 +339,7 @@ def build_match_dict(in_port=None, vlan=None,
 
 
 def flowmod(cookie, command, table_id, priority, out_port, out_group,
-            match_fields, inst, hard_timeout, idle_timeout):
+            match_fields, inst, hard_timeout, idle_timeout, flags=0):
     return parser.OFPFlowMod(
         datapath=None,
         cookie=cookie,
@@ -351,7 +351,8 @@ def flowmod(cookie, command, table_id, priority, out_port, out_group,
         match=match_fields,
         instructions=inst,
         hard_timeout=hard_timeout,
-        idle_timeout=idle_timeout)
+        idle_timeout=idle_timeout,
+        flags=flags)
 
 
 def group_act(group_id):

--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -3493,7 +3493,7 @@ vlans:
         description: "untagged"
 """
     CONFIG = """
-        timeout: 10
+        timeout: 8
         hard_timeout_enabled: false
         interfaces:
             %(port_1)d:
@@ -3509,36 +3509,85 @@ vlans:
                 native_vlan: 100
                 description: "b4"
 """
+    def wait_for_flowremoved_msg(self, src_mac=None, dst_mac=None, timeout=30):
+        pattern = "OFPFlowRemoved"
+        mac = None
+        if src_mac:
+            pattern = "OFPFlowRemoved(.*)'eth_src': '%s'" % src_mac
+            mac = src_mac
+        if dst_mac:
+            pattern = "OFPFlowRemoved(.*)'eth_dst': '%s'" % dst_mac
+            mac = dst_mac
+        for i in range(0, timeout):
+            for _, debug_log in self._get_ofchannel_logs():
+                match = re.search(pattern, open(debug_log).read())
+            if match:
+                return
+            time.sleep(1)
+        self.assertTrue(False,
+                msg='Not received OFPFlowRemoved for host %s' % mac)
+
+    def wait_for_host_log_msg(self, host_mac, msg, timeout=15):
+        controller = self._get_controller()
+        count = 0
+        for _ in range(0, timeout):
+            count = controller.cmd('grep -c "%s %s" %s' % (
+                msg, host_mac, self.env['faucet']['FAUCET_LOG']))
+            if int(count) != 0:
+                break
+            time.sleep(1)
+        self.assertGreaterEqual(int(count), 1,
+            'log msg "%s" for host %s not found' % (msg, host_mac))
 
     def test_untagged(self):
         self.net.pingAll()
         first_host, second_host = self.net.hosts[:2]
-        third_host, fourth_host = self.net.hosts[2:]
-        first_host.cmd('ping %s &' % second_host.IP())
-        time.sleep(30) # wait enough for hosts to expire
-        controller = self._get_controller()
-        for mac in (first_host.MAC(), second_host.MAC()):
-            count = controller.cmd(
-                'grep -c "refreshing host %s" %s' % (mac, self.env['faucet']['FAUCET_LOG']))
-            self.assertGreaterEqual(int(count), 1)
-        # expect see two hosts expired in the controller log
-        for mac in (third_host.MAC(), fourth_host.MAC()):
-            count = controller.cmd(
-                'grep -c "expiring host %s" %s' % (mac, self.env['faucet']['FAUCET_LOG']))
-            self.assertEqual(int(count), 1)
-        # now move host 2 to host 3
-        self.swap_host_macs(second_host, third_host)
-        self.require_host_learned(second_host)
-        self.assertEquals(0, self.net.ping((first_host, second_host)))
-        # expect old flows of host 2 disappear from switch
+        self.swap_host_macs(first_host, second_host)
+        self.wait_for_flowremoved_msg(src_mac=second_host.MAC())
+        self.require_host_learned(first_host)
         self.assertTrue(self.matching_flow_present(
             match={
-                u'in_port': int(self.port_map['port_2']),
-                u'dl_src': u'%s' % second_host.MAC()},
-            timeout=5))
+                u'in_port': int(self.port_map['port_1']),
+                u'dl_src': u'%s' % first_host.MAC()}))
         self.assertFalse(self.matching_flow_present(
             match={
                 u'in_port': int(self.port_map['port_2']),
+                u'dl_src': u'%s' % first_host.MAC()},
+            timeout=1))
+
+class FaucetDisableHardTimeoutRuleExpiredTest(FaucetDisableHardTimeoutTest):
+
+    def test_untagged(self):
+        """Host that is actively sending should have its dst rule renewed as the
+        rule expires. Host that is not sending expires as usual.
+        """
+        self.net.pingAll()
+        first_host, second_host = self.net.hosts[:2]
+        third_host, fourth_host = self.net.hosts[2:]
+        self.host_ipv4_alias(first_host, ipaddress.ip_interface(u'10.99.99.1/24'))
+        first_host.cmd('ping 10.0.0.2 -I 10.99.99.1 &')
+        second_host.cmd('ifconfig %s 0' % second_host.defaultIntf())
+        third_host.cmd('ifconfig %s 0' % third_host.defaultIntf())
+        self.wait_for_flowremoved_msg(src_mac=second_host.MAC())
+        # expect to see dst rule present
+        self.wait_for_host_log_msg(first_host.MAC(), 'refreshing host')
+        self.assertTrue(self.matching_flow_present(
+            match={u'dl_dst': u'%s' % first_host.MAC()},
+            table_id=self.ETH_DST_TABLE))
+        self.wait_for_host_log_msg(second_host.MAC(), 'expiring host')
+        self.assertFalse(self.matching_flow_present(
+            match={
+                u'in_port': int(self.port_map['port_2']),
+                u'dl_src': u'%s' % second_host.MAC()},
+            timeout=2))
+        self.wait_for_host_log_msg(third_host.MAC(), 'expiring host')
+        self.assertFalse(self.matching_flow_present(
+            match={
+                u'in_port': int(self.port_map['port_3']),
                 u'dl_src': u'%s' % third_host.MAC()},
-            timeout=18))
+            timeout=2))
+        self.assertFalse(self.matching_flow_present(
+            match={u'dl_dst': u'%s' % third_host.MAC()},
+            table_id=self.ETH_DST_TABLE,
+            timeout=2))
 

--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -3899,7 +3899,7 @@ acls:
             source_host, overridden_host, rewrite_host, overridden_host)
 
 
-class FaucetDisableHardTimeoutTest(FaucetUntaggedTest):
+class FaucetWithUseIdleTimeoutTest(FaucetUntaggedTest):
     CONFIG_GLOBAL = """
 vlans:
     100:
@@ -3907,7 +3907,7 @@ vlans:
 """
     CONFIG = """
         timeout: 8
-        hard_timeout_enabled: false
+        use_idle_timeout: true
         interfaces:
             %(port_1)d:
                 native_vlan: 100
@@ -3968,7 +3968,7 @@ vlans:
                 u'dl_src': u'%s' % first_host.MAC()},
             timeout=1))
 
-class FaucetDisableHardTimeoutRuleExpiredTest(FaucetDisableHardTimeoutTest):
+class FaucetWithUseIdleTimeoutRuleExpiredTest(FaucetWithUseIdleTimeoutTest):
 
     def test_untagged(self):
         """Host that is actively sending should have its dst rule renewed as the


### PR DESCRIPTION
This is to replace #485.
By replacing hard-timeout with idle-timeout, we can miminize packet-ins to zero and keep the network working for all active hosts without Faucet running.
It is configurable.