### PR TITLE
Fix pip install

### DIFF
--- a/docs/README_install.rst
+++ b/docs/README_install.rst
@@ -138,7 +138,7 @@ To install the latest pip package:
 .. code:: bash
 
   apt-get install python-dev
-  pip install ryu-faucet
+  pip install faucet
 
 To install the latest code from git, via pip:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ influxdb
 ipaddress
 networkx
 numpy
+pbr
 prometheus_client
 pyyaml
 ryu==4.14


### PR DESCRIPTION
Faucet requires pbr but is not included in the requirements.

Also the package in pypi is called 'faucet' and not 'ryu-faucet'

Fixes #724