### PR TITLE
Fix pip install

### DIFF
--- a/docs/README_install.rst
+++ b/docs/README_install.rst
@@ -138,7 +138,7 @@ To install the latest pip package:
 .. code:: bash
 
   apt-get install python-dev
-  pip install ryu-faucet
+  pip install faucet
 
 To install the latest code from git, via pip:
 

--- a/setup.py
+++ b/setup.py
@@ -55,13 +55,25 @@ def install_configs():
         else:
             raise
 
-os.environ["PBR_VERSION"] = parse_version()
+# This is a workaround to override version code from pbr as
+# PBR_VERSION env variable interferes with the installation
+# of pbr itself as part of setup_requires
+#
+# See launchpad bug: https://bugs.launchpad.net/pbr/+bug/1256138
+with open("METADATA", "w") as fd:
+    fd.write("Name: faucet\n")
+    fd.write("Version: %s\n" % parse_version())
 
-setup(
-    name='faucet',
-    setup_requires=['pbr>=1.9', 'setuptools>=17.1'],
-    pbr=True
-)
+try:
+    setup(
+        name='faucet',
+        setup_requires=['pbr>=1.9', 'setuptools>=17.1'],
+        pbr=True
+    )
 
-if 'install' in sys.argv or 'bdist_wheel' in sys.argv:
-    install_configs()
+    if 'install' in sys.argv or 'bdist_wheel' in sys.argv:
+        install_configs()
+finally:
+    if os.path.isfile("METADATA"):
+        os.remove("METADATA")
+


### PR DESCRIPTION
If pbr is not installed, easy_install is required to get latest
version. Setting the PBR_VERSION env variable is breaking the
process. See: https://bugs.launchpad.net/pbr/+bug/1256138

This is a workaround by using a temp METADATA file to force
force faucet's version.

Also the package in pypi is called 'faucet' and not 'ryu-faucet'

Fixes #724