### PR TITLE
FAUCET MAC address now configurable per VLAN

### DIFF
--- a/faucet/valve_packet.py
+++ b/faucet/valve_packet.py
@@ -299,11 +299,12 @@ def icmpv6_echo_reply(vid, eth_src, eth_dst, src_ip, dst_ip, hop_limit,
     return pkt
 
 
-def router_advert(vid, eth_src, eth_dst, src_ip, dst_ip,
+def router_advert(vlan, vid, eth_src, eth_dst, src_ip, dst_ip,
                   vips, pi_flags=0x6):
     """Return IPv6 ICMP echo reply packet.
 
     Args:
+        vlan (VLAN): VLAN instance.
         vid (int or None): VLAN VID to use (or None).
         eth_src (str): source Ethernet MAC address.
         eth_dst (str): dest Ethernet MAC address.

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -822,7 +822,7 @@ class ValveIPv6RouteManager(ValveRouteManager):
                 for vip in link_local_vips:
                     if src_ip in vip.network:
                         ra_advert = valve_packet.router_advert(
-                            vid, vlan.faucet_mac, eth_src,
+                            vlan, vid, vlan.faucet_mac, eth_src,
                             vip.ip, src_ip, other_vips)
                         ofmsgs.append(
                             valve_of.packetout(port.number, ra_advert.data))

--- a/faucet/vlan.py
+++ b/faucet/vlan.py
@@ -29,6 +29,9 @@ except ImportError:
     from faucet import valve_of
 
 
+FAUCET_MAC = '0e:00:00:00:00:01'
+
+
 class VLAN(Conf):
     """Implement FAUCET configuration for a VLAN."""
 
@@ -36,6 +39,7 @@ class VLAN(Conf):
     untagged = None
     vid = None
     faucet_vips = None
+    faucet_mac = None
     bgp_as = None
     bgp_local_address = None
     bgp_port = None
@@ -62,6 +66,8 @@ class VLAN(Conf):
         'description': None,
         'acl_in': None,
         'faucet_vips': None,
+        'faucet_mac': FAUCET_MAC,
+        # set MAC for FAUCET VIPs on this VLAN
         'unicast_flood': True,
         'bgp_as': None,
         'bgp_local_address': None,
@@ -86,6 +92,7 @@ class VLAN(Conf):
         'description': str,
         'acl_in': (int, str),
         'faucet_vips': list,
+        'faucet_mac': str,
         'unicast_flood': bool,
         'bgp_as': int,
         'bgp_local_address': str,
@@ -225,7 +232,7 @@ class VLAN(Conf):
                 (self.vid, self.tagged_flood_ports(False)),
                 (None, self.untagged_flood_ports(False))):
             if ports:
-                pkt = packet_builder(vid, *args)
+                pkt = packet_builder(self, vid, *args)
                 for port in ports:
                     ofmsgs.append(valve_of.packetout(port.number, pkt.data))
         return ofmsgs

--- a/tests/faucet_mininet_test_base.py
+++ b/tests/faucet_mininet_test_base.py
@@ -1273,15 +1273,16 @@ dbs:
         host.cmd(del_cmd)
         self.assertEquals('', host.cmd(add_cmd))
 
+    def _ip_neigh(self, host, ipa, ip_ver):
+        neighbors = host.cmd('ip -%u neighbor show %s' % (ip_ver, ipa))
+        if neighbors:
+            return neighbors.split()[4]
+        return None
+
     def _verify_host_learned_mac(self, host, ipa, ip_ver, mac, retries):
         for _ in range(retries):
-            neighbors = host.cmd('ip -%u neighbor show' % ip_ver)
-            for neighbor_line in neighbors.splitlines():
-                neighbor_fields = neighbor_line.strip().split(' ')
-                learned_ipa = neighbor_fields[0]
-                learned_mac = neighbor_fields[4]
-                if learned_ipa == str(ipa) and learned_mac == mac:
-                    return
+            if self._ip_neigh(ipa, ip_ver) == mac:
+                return
             time.sleep(1)
         self.fail(
             'could not verify %s resolved to %s (%s)' % (ipa, mac, neighbors))

--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -1402,7 +1402,7 @@ vlans:
         first_host = self.net.hosts[0]
         for vip in ('fe80::1:254', 'fc00::1:254', 'fc00::2:254'):
             self.assertEquals(
-                self.FAUCET_MAC,
+                self.FAUCET_MAC.upper(),
                 first_host.cmd('ndisc6 -q %s %s' % (vip, first_host.defaultIntf())).strip())
 
     def test_rdisc6(self):

--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -2230,6 +2230,8 @@ vlans:
 
 class FaucetUntaggedIPv4InterVLANRouteTest(FaucetUntaggedTest):
 
+    FAUCET_MAC2 = '0e:00:00:00:00:02'
+
     CONFIG_GLOBAL = """
 vlans:
     100:
@@ -2238,10 +2240,11 @@ vlans:
     200:
         description: "200"
         faucet_vips: ["10.200.0.254/24"]
+        faucet_mac: "%s"
 routers:
     router-1:
         vlans: [100, 200]
-"""
+""" % FAUCET_MAC2
 
     CONFIG = """
         arp_neighbor_timeout: 2
@@ -2275,6 +2278,10 @@ routers:
         self.one_ipv4_ping(second_host, second_faucet_vip.ip)
         self.one_ipv4_ping(first_host, second_host_ip.ip)
         self.one_ipv4_ping(second_host, first_host_ip.ip)
+        self.assertEquals(
+            self._ip_neigh(first_host, first_faucet_vip.ip, 4), self.FAUCET_MAC)
+        self.assertEquals(
+            self._ip_neigh(second_host, second_faucet_vip.ip, 4), self.FAUCET_MAC2)
 
 
 class FaucetUntaggedMixedIPv4RouteTest(FaucetUntaggedTest):

--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -1374,12 +1374,15 @@ vlans:
 
 class FaucetUntaggedIPv6RATest(FaucetUntaggedTest):
 
+    FAUCET_MAC = "0e:00:00:00:00:99"
+
     CONFIG_GLOBAL = """
 vlans:
     100:
         description: "untagged"
         faucet_vips: ["fe80::1:254/64", "fc00::1:254/112", "fc00::2:254/112", "10.0.0.254/24"]
-"""
+        faucet_mac: "%s"
+""" % FAUCET_MAC
 
     CONFIG = """
         advertise_interval: 5

--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -1402,7 +1402,7 @@ vlans:
         first_host = self.net.hosts[0]
         for vip in ('fe80::1:254', 'fc00::1:254', 'fc00::2:254'):
             self.assertEquals(
-                '0E:00:00:00:00:01',
+                self.FAUCET_MAC,
                 first_host.cmd('ndisc6 -q %s %s' % (vip, first_host.defaultIntf())).strip())
 
     def test_rdisc6(self):
@@ -1417,7 +1417,7 @@ vlans:
         first_host = self.net.hosts[0]
         tcpdump_filter = ' and '.join((
             'ether dst 33:33:00:00:00:01',
-            'ether src 0e:00:00:00:00:01',
+            'ether src %s' % self.FAUCET_MAC,
             'icmp6',
             'ip6[40] == 134',
             'ip6 host fe80::1:254'))
@@ -1427,7 +1427,7 @@ vlans:
                 r'fe80::1:254 > ff02::1:.+ICMP6, router advertisement',
                 r'fc00::1:0/112, Flags \[onlink, auto\]',
                 r'fc00::2:0/112, Flags \[onlink, auto\]',
-                r'source link-address option \(1\), length 8 \(1\): 0e:00:00:00:00:01'):
+                r'source link-address option \(1\), length 8 \(1\): %s' % self.FAUCET_MAC):
             self.assertTrue(
                 re.search(ra_required, tcpdump_txt),
                 msg='%s: %s' % (ra_required, tcpdump_txt))
@@ -1435,7 +1435,7 @@ vlans:
     def test_rs_reply(self):
         first_host = self.net.hosts[0]
         tcpdump_filter = ' and '.join((
-            'ether src 0e:00:00:00:00:01',
+            'ether src %s' % self.FAUCET_MAC,
             'ether dst %s' % first_host.MAC(),
             'icmp6',
             'ip6[40] == 134',
@@ -1449,7 +1449,7 @@ vlans:
                 r'fe80::1:254 > fe80::.+ICMP6, router advertisement',
                 r'fc00::1:0/112, Flags \[onlink, auto\]',
                 r'fc00::2:0/112, Flags \[onlink, auto\]',
-                r'source link-address option \(1\), length 8 \(1\): 0e:00:00:00:00:01'):
+                r'source link-address option \(1\), length 8 \(1\): %s' % self.FAUCET_MAC):
             self.assertTrue(
                 re.search(ra_required, tcpdump_txt),
                 msg='%s: %s (%s)' % (ra_required, tcpdump_txt, tcpdump_filter))


### PR DESCRIPTION
FAUCET's MAC address used to be globally hard coded. You can now configure it on a per VLAN basis.

vlans:
    100:
        faucet_vips: ["fc00::1:254/112"]
        faucet_mac: "0e:00:00:00:00:99"