### PR TITLE
Pin to scapy 2.3.2, as 2.3.3 fails on Ubuntu 17 hosts with IPv6 even …

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -53,7 +53,7 @@ RUN \
   pip install setuptools wheel virtualenv --upgrade && \
   pip install -r /faucet-src/test-requirements.txt && \
   pip install exabgp==3.4.20 && \
-  pip install scapy && \
+  pip install scapy==2.3.2 && \
   pip3 install setuptools wheel virtualenv --upgrade && \
   pip3 install -r /faucet-src/requirements.txt && \
   pip3 install -r /faucet-src/test-requirements.txt && \


### PR DESCRIPTION
…under Docker.