### PR TITLE
Add meter instruction in aruba_pipeline.json

### DIFF
--- a/etc/ryu/faucet/aruba_pipeline.json
+++ b/etc/ryu/faucet/aruba_pipeline.json
@@ -124,6 +124,10 @@
                     {
                         "name": "OFPIT_APPLY_ACTIONS",
                         "type": 4
+                    },
+                    {
+                        "name": "OFPIT_METER",
+                        "type": 6
                     }
                 ]
             },
@@ -475,6 +479,10 @@
                     {
                         "name": "OFPIT_APPLY_ACTIONS",
                         "type": 4
+                    },
+                    {
+                        "name": "OFPIT_METER",
+                        "type": 6
                     }
                 ]
             },


### PR DESCRIPTION
Now that FAUCET supports meter instruction in user defined ACLs,
adding meter instruction in the pipeline definition for Aruba devices in tables 'Port ACL' and 'VLAN ACL'.