### PR TITLE
Allow masks to be set on UDP/TCP/SCTP ports

### DIFF
--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -19,7 +19,7 @@
 
 import ipaddress
 
-from ryu.lib.ofctl_utils import str_to_int, to_match_ip, to_match_masked_int, to_match_vid, to_match_eth, OFCtlUtil 
+from ryu.lib.ofctl_utils import str_to_int, to_match_ip, to_match_masked_int, to_match_vid, to_match_eth, OFCtlUtil
 from ryu.ofproto import ether
 from ryu.ofproto import inet
 from ryu.ofproto import ofproto_v1_3 as ofp

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -19,7 +19,7 @@
 
 import ipaddress
 
-from ryu.lib.ofctl_utils import str_to_int, to_match_ip, to_match_masked_int, to_match_vid, to_match_eth, OFCtlUtil
+from ryu.lib.ofctl_utils import str_to_int, to_match_ip, to_match_masked_int, to_match_eth, to_match_vid, OFCtlUtil
 from ryu.ofproto import ether
 from ryu.ofproto import inet
 from ryu.ofproto import ofproto_v1_3 as ofp
@@ -295,6 +295,10 @@ def match(match_fields):
     return parser.OFPMatch(**match_fields)
 
 
+def valve_match_vid(value):
+    return to_match_vid(value, ofp.OFPVID_PRESENT)
+
+
 def match_from_dict(match_dict):
     convert = {
         'in_port': OFCtlUtil(ofp).ofp_port_from_user,
@@ -306,8 +310,8 @@ def match_from_dict(match_dict):
         'eth_src': to_match_eth,
         'dl_type': str_to_int,
         'eth_type': str_to_int,
-        'dl_vlan': to_match_vid,
-        'vlan_vid': to_match_vid,
+        'dl_vlan': valve_match_vid,
+        'vlan_vid': valve_match_vid,
         'vlan_pcp': str_to_int,
         'ip_dscp': str_to_int,
         'ip_ecn': str_to_int,

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -362,8 +362,10 @@ def match_from_dict(match_dict):
             match_dict.get('eth_type') == ether.ETH_TYPE_ARP):
         if 'nw_src' in match_dict and 'arp_spa' not in match_dict:
             match_dict['arp_spa'] = match_dict['nw_src']
-        else:
-            assert 'Unknown match field: %s' % key
+            del match_dict['nw_src']
+        if 'nw_dst' in match_dict and 'arp_tpa' not in match_dict:
+            match_dict['arp_tpa'] = match_dict['nw_dst']
+            del match_dict['nw_dst']
 
     kwargs = {}
     for key, value in list(match_dict.items()):
@@ -386,7 +388,7 @@ def match_from_dict(match_dict):
                 # others
                 kwargs[key] = value
         else:
-             assert 'Unknown match field: %s' % key
+            assert 'Unknown match field: %s' % key
 
     return parser.OFPMatch(**kwargs)
 

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -17,14 +17,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import namedtuple
 import ipaddress
 
-from ryu.lib import ofctl_v1_3 as ofctl
+from ryu.lib.ofctl_utils import str_to_int, to_match_ip, to_match_masked_int, to_match_vid, to_match_eth, OFCtlUtil 
 from ryu.ofproto import ether
+from ryu.ofproto import inet
 from ryu.ofproto import ofproto_v1_3 as ofp
 from ryu.ofproto import ofproto_v1_3_parser as parser
-
 
 VLAN_GROUP_OFFSET = 4096
 ROUTE_GROUP_OFFSET = VLAN_GROUP_OFFSET * 2
@@ -297,10 +296,99 @@ def match(match_fields):
 
 
 def match_from_dict(match_dict):
-    null_dp = namedtuple('null_dp', 'ofproto_parser')
-    null_dp.ofproto_parser = parser
-    acl_match = ofctl.to_match(null_dp, match_dict)
-    return acl_match
+    convert = {
+        'in_port': OFCtlUtil(ofp).ofp_port_from_user,
+        'in_phy_port': str_to_int,
+        'metadata': to_match_masked_int,
+        'dl_dst': to_match_eth,
+        'dl_src': to_match_eth,
+        'eth_dst': to_match_eth,
+        'eth_src': to_match_eth,
+        'dl_type': str_to_int,
+        'eth_type': str_to_int,
+        'dl_vlan': to_match_vid,
+        'vlan_vid': to_match_vid,
+        'vlan_pcp': str_to_int,
+        'ip_dscp': str_to_int,
+        'ip_ecn': str_to_int,
+        'nw_proto': str_to_int,
+        'ip_proto': str_to_int,
+        'nw_src': to_match_ip,
+        'nw_dst': to_match_ip,
+        'ipv4_src': to_match_ip,
+        'ipv4_dst': to_match_ip,
+        'tp_src': to_match_masked_int,
+        'tp_dst': to_match_masked_int,
+        'tcp_src': to_match_masked_int,
+        'tcp_dst': to_match_masked_int,
+        'udp_src': to_match_masked_int,
+        'udp_dst': to_match_masked_int,
+        'sctp_src': to_match_masked_int,
+        'sctp_dst': to_match_masked_int,
+        'icmpv4_type': str_to_int,
+        'icmpv4_code': str_to_int,
+        'arp_op': str_to_int,
+        'arp_spa': to_match_ip,
+        'arp_tpa': to_match_ip,
+        'arp_sha': to_match_eth,
+        'arp_tha': to_match_eth,
+        'ipv6_src': to_match_ip,
+        'ipv6_dst': to_match_ip,
+        'ipv6_flabel': str_to_int,
+        'icmpv6_type': str_to_int,
+        'icmpv6_code': str_to_int,
+        'ipv6_nd_target': to_match_ip,
+        'ipv6_nd_sll': to_match_eth,
+        'ipv6_nd_tll': to_match_eth,
+        'mpls_label': str_to_int,
+        'mpls_tc': str_to_int,
+        'mpls_bos': str_to_int,
+        'pbb_isid': to_match_masked_int,
+        'tunnel_id': to_match_masked_int,
+        'ipv6_exthdr': to_match_masked_int
+    }
+
+    keys = {
+        'dl_dst': 'eth_dst',
+        'dl_src': 'eth_src',
+        'dl_type': 'eth_type',
+        'dl_vlan': 'vlan_vid',
+        'nw_src': 'ipv4_src',
+        'nw_dst': 'ipv4_dst',
+        'nw_proto': 'ip_proto'
+    }
+
+    if (match_dict.get('dl_type') == ether.ETH_TYPE_ARP or
+            match_dict.get('eth_type') == ether.ETH_TYPE_ARP):
+        if 'nw_src' in match_dict and 'arp_spa' not in match_dict:
+            match_dict['arp_spa'] = match_dict['nw_src']
+        else:
+            assert 'Unknown match field: %s' % key
+
+    kwargs = {}
+    for key, value in list(match_dict.items()):
+        if key in keys:
+            # For old field name
+            key = keys[key]
+        if key in convert:
+            value = convert[key](value)
+            if key == 'tp_src' or key == 'tp_dst':
+                # TCP/UDP port
+                conv = {inet.IPPROTO_TCP: {'tp_src': 'tcp_src',
+                                           'tp_dst': 'tcp_dst'},
+                        inet.IPPROTO_UDP: {'tp_src': 'udp_src',
+                                           'tp_dst': 'udp_dst'}}
+                ip_proto = match_dict.get(
+                    'nw_proto', match_dict.get('ip_proto', 0))
+                key = conv[ip_proto][key]
+                kwargs[key] = value
+            else:
+                # others
+                kwargs[key] = value
+        else:
+             assert 'Unknown match field: %s' % key
+
+    return parser.OFPMatch(**kwargs)
 
 
 def _match_ip_masked(ipa):

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -452,13 +452,13 @@ class ValveRouteManager(object):
             faucet_vip = vlan.ip_in_vip_subnet(dst_ip)
             if faucet_vip and not vlan.is_faucet_vip(dst_ip):
                 if self._is_host_fib_route(vlan, dst_ip):
-                    self.logger.info(
+                    self.logger.debug(
                         'not proactively learning %s, already trying on VLAN %u' % (
                             dst_ip, vlan.vid))
                     break
                 if (limit is not None and
                         len(self._vlan_nexthop_cache(vlan)) >= limit):
-                    self.logger.info(
+                    self.logger.debug(
                         'not proactively learning %s, at limit %u on VLAN %u' % (
                             dst_ip, limit, vlan.vid))
                     break
@@ -475,7 +475,7 @@ class ValveRouteManager(object):
                 resolve_flows = self.resolve_gw_on_vlan(
                     vlan, faucet_vip, dst_ip)
                 ofmsgs.extend(resolve_flows)
-                self.logger.info(
+                self.logger.debug(
                     'proactively resolving %s (%u flows) on VLAN %u' % (
                         dst_ip, len(resolve_flows), vlan.vid))
                 break

--- a/tests/faucet_mininet_test_base.py
+++ b/tests/faucet_mininet_test_base.py
@@ -1157,17 +1157,21 @@ dbs:
         else:
             self.fail('no flow matching %s' % match)
 
-    def verify_tp_dst_blocked(self, port, first_host, second_host, table_id=0):
+    def verify_tp_dst_blocked(self, port, first_host, second_host, table_id=0, mask=None):
         """Verify that a TCP port on a host is blocked from another host."""
         self.serve_hello_on_tcp_port(second_host, port)
         self.assertEquals(
             '', first_host.cmd(faucet_mininet_test_util.timeout_cmd(
                 'nc %s %u' % (second_host.IP(), port), 10)))
         if table_id is not None:
+            if mask is None:
+                match_port = int(port)
+            else:
+                match_port = '/'.join((str(port), str(mask)))
             self.wait_nonzero_packet_count_flow(
-                {u'tp_dst': int(port)}, table_id=table_id)
+                {u'tp_dst': match_port}, table_id=table_id)
 
-    def verify_tp_dst_notblocked(self, port, first_host, second_host, table_id=0):
+    def verify_tp_dst_notblocked(self, port, first_host, second_host, table_id=0, mask=None):
         """Verify that a TCP port on a host is NOT blocked from another host."""
         self.serve_hello_on_tcp_port(second_host, port)
         self.assertEquals(

--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -1810,15 +1810,22 @@ acls:
         - rule:
             dl_type: 0x800
             nw_proto: 6
+            tp_dst: 5002
+            actions:
+                allow: 1
+        - rule:
+            dl_type: 0x800
+            nw_proto: 6
             tp_dst: 5001
             actions:
                 allow: 0
         - rule:
             dl_type: 0x800
             nw_proto: 6
-            tp_dst: 5002
+            # Match packets > 1024
+            tp_dst: 1024/1024
             actions:
-                allow: 1
+                allow: 0
         - rule:
             actions:
                 allow: 1
@@ -1839,6 +1846,12 @@ acls:
                 native_vlan: 100
                 description: "b4"
 """
+
+    def test_port_gt1024_blocked(self):
+        self.ping_all_when_learned()
+        first_host, second_host = self.net.hosts[0:2]
+        self.verify_tp_dst_blocked(1024, first_host, second_host, mask=1024)
+        self.verify_tp_dst_notblocked(1023, first_host, second_host, table_id=None)
 
     def test_port5001_blocked(self):
         self.ping_all_when_learned()

--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -1822,7 +1822,7 @@ acls:
         - rule:
             dl_type: 0x800
             nw_proto: 6
-            # Match packets > 1024
+            # Match packets > 1023
             tp_dst: 1024/1024
             actions:
                 allow: 0
@@ -1847,7 +1847,7 @@ acls:
                 description: "b4"
 """
 
-    def test_port_gt1024_blocked(self):
+    def test_port_gt1023_blocked(self):
         self.ping_all_when_learned()
         first_host, second_host = self.net.hosts[0:2]
         self.verify_tp_dst_blocked(1024, first_host, second_host, mask=1024)


### PR DESCRIPTION
We now allow setting a mask on transport ports, which is key to ACL rule scaling.

Eg:

        - rule:
            dl_type: 0x800
            nw_proto: 6
            # Match packets > 1023
            tp_dst: 1024/1024
            actions:
                allow: 0

TCP_DST et al are marked "not maskable" in the OF1.3.5 spec (p.127, https://www.opennetworking.org/images/stories/downloads/sdn-resources/onf-specifications/openflow/openflow-switch-v1.3.5.pdf). However, OVS has set a precedent since version 1.6/2012 of supporting masking (http://openvswitch.org/support/dist-docs/ovs-fields.7.pdf, https://mailman.stanford.edu/pipermail/openflow-discuss/2012-April/003139.html).

Multiple hardware has also been tested with mask support.