### PR TITLE
Gauge prom

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ RUN \
 
 VOLUME ["/etc/ryu/faucet/", "/var/log/ryu/faucet/"]
 
-EXPOSE 6653 9244
+EXPOSE 6653 9302
 
 CMD ["ryu-manager", "faucet.faucet"]

--- a/Dockerfile.gauge
+++ b/Dockerfile.gauge
@@ -20,6 +20,6 @@ RUN \
 
 VOLUME ["/etc/ryu/faucet/", "/var/log/ryu/faucet/"]
 
-EXPOSE 6653
+EXPOSE 6653 9303
 
 CMD ["ryu-manager", "faucet.gauge"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,6 +33,7 @@ services:
             - './etc/prometheus/faucet.rules:/etc/prometheus/faucet.rules'
         links:
             - faucet
+            - gauge
 
     grafana:
         restart: always

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -58,6 +58,7 @@ services:
             - '/etc/ryu/faucet:/etc/ryu/faucet'
         ports:
             - '6654:6653'
+            - '9303'
         links:
             - couchdb
             - influxdb
@@ -73,4 +74,4 @@ services:
             - '/etc/ryu/faucet:/etc/ryu/faucet'
         ports:
             - '6653:6653'
-            - '9244'
+            - '9302'

--- a/docs/README.docker.md
+++ b/docs/README.docker.md
@@ -37,11 +37,11 @@ To pull and run the latest git version of Faucet:
       -v /etc/ryu/faucet/:/etc/ryu/faucet/ \
       -v /var/log/ryu/faucet/:/var/log/ryu/faucet/ \
       -p 6653:6653 \
-      -p 9244:9244 \
+      -p 9302:9302 \
       faucet/faucet
 ```
 
-Port 6653 is used for OpenFlow, port 9244 is used for Prometheus - port 9244 may be omitted if
+Port 6653 is used for OpenFlow, port 9302 is used for Prometheus - port 9302 may be omitted if
 you do not need Prometheus.
 
 To pull and run the latest git version of Gauge:

--- a/etc/prometheus/faucet.rules
+++ b/etc/prometheus/faucet.rules
@@ -5,3 +5,12 @@ instance_dpid:of_flowmsgs_sent:rate1m = rate(of_flowmsgs_sent[1m])
 # Sum hosts learned on VLANs
 instance:vlan_hosts_learned:sum = sum(vlan_hosts_learned) by (instance,vlan)
 instance:learned_macs:sum = count(count_values("mac", learned_macs{} != 0) by (vlan)) by (vlan)
+
+# Convert Port stats to rates
+instance_dpid:port_packets_in:rate1m = rate(packets_in[1m])
+instance_dpid:port_packets_out:rate1m = rate(packets_out[1m])
+instance_dpid:port_bytes_in:rate1m = rate(bytes_in[1m])
+instance_dpid:port_bytes_out:rate1m = rate(bytes_out[1m])
+instance_dpid:port_dropped_in:rate1m = rate(dropped_in[1m])
+instance_dpid:port_dropped_out:rate1m = rate(dropped_out[1m])
+instance_dpid:port_errors_in:rate1m = rate(errors_in[1m])

--- a/etc/prometheus/prometheus-docker-compose.yml
+++ b/etc/prometheus/prometheus-docker-compose.yml
@@ -7,3 +7,6 @@ scrape_configs:
   - job_name: 'faucet'
     static_configs:
       - targets: ['faucet:9302']
+  - job_name: 'gauge'
+    static_configs:
+      - targets: ['gauge:9303']

--- a/etc/prometheus/prometheus-docker-compose.yml
+++ b/etc/prometheus/prometheus-docker-compose.yml
@@ -6,4 +6,4 @@ rule_files:
 scrape_configs:
   - job_name: 'faucet'
     static_configs:
-      - targets: ['faucet:9244']
+      - targets: ['faucet:9302']

--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -127,7 +127,7 @@ class Faucet(app_manager.RyuApp):
         self.valves = {}
 
         # Start Prometheus
-        prom_port = int(os.getenv('FAUCET_PROMETHEUS_PORT', '9244'))
+        prom_port = int(os.getenv('FAUCET_PROMETHEUS_PORT', '9302'))
         prom_addr = os.getenv('FAUCET_PROMETHEUS_ADDR', '')
         self.metrics = faucet_metrics.FaucetMetrics(
             prom_port, prom_addr)

--- a/faucet/gauge_prom.py
+++ b/faucet/gauge_prom.py
@@ -1,0 +1,69 @@
+import os
+from prometheus_client import Counter, start_http_server
+from prometheus_client import Gauge as PromGauge # *sigh*
+try:
+    from gauge_pollers import GaugePortStatsPoller
+    from valve_of import devid_present
+    from valve_util import dpid_log
+except ImportError:
+    from faucet.gauge_pollers import GaugePortStatsPoller
+    from faucet.valve_of import devid_present
+    from faucet.valve_util import dpid_log
+
+class GaugePortStatsPrometheusPoller(GaugePortStatsPoller):
+    '''Exports port stats to prometheus.
+
+    Note: the prometheus server starts in a separate thread. Whereas Ryu is
+    single-threaded and event based.
+    '''
+
+    def __init__(self, conf, logger):
+        super(GaugePortStatsPrometheusPoller, self).__init__(conf, logger)
+        self.bytes_in = PromGauge(
+            'bytes_in',
+            '',
+            ['dp_id', 'port_name'])
+        self.bytes_out = PromGauge(
+            'bytes_out',
+            '',
+            ['dp_id', 'port_name'])
+        self.dropped_in = PromGauge(
+            'dropped_in',
+            '',
+            ['dp_id', 'port_name'])
+        self.dropped_out = PromGauge(
+            'dropped_out',
+            '',
+            ['dp_id', 'port_name'])
+        self.errors_in = PromGauge(
+            'errors_in',
+            '',
+            ['dp_id', 'port_name'])
+        self.packets_in = PromGauge(
+            'packets_in',
+            '',
+            ['dp_id', 'port_name'])
+        self.packets_out = PromGauge(
+            'packets_out',
+            '',
+            ['dp_id', 'port_name'])
+        self.port_state_reason = PromGauge(
+            'port_state_reason',
+            '',
+            ['dp_id', 'port_name'])
+        try:
+            self.logger.debug('Attempting to start Prometheus server')
+            start_http_server(9303, os.getenv('FAUCET_PROMETHEUS_ADDR', ''))
+        except OSError:
+            # Prometheus server already started
+            self.logger.debug('Prometheus server already running')
+            pass
+
+    def update(self, rcv_time, dp_id, msg):
+        super(GaugePortStatsPrometheusPoller, self).update(rcv_time, dp_id, msg)
+        self.logger.debug('Updating Prometheus Stats')
+        for stat in msg.body:
+            port_name = self._stat_port_name(msg, stat, dp_id)
+            for stat_name, stat_val in self._format_port_stats('_', stat):
+                self.__dict__[stat_name].labels(
+                    dp_id=hex(dp_id), port_name=port_name).set(stat_val)

--- a/faucet/watcher.py
+++ b/faucet/watcher.py
@@ -6,11 +6,13 @@ try:
     from gauge_influx import GaugePortStateInfluxDBLogger, GaugePortStatsInfluxDBLogger, GaugeFlowTableInfluxDBLogger
     from gauge_nsodbc import GaugeFlowTableDBLogger
     from gauge_pollers import GaugePortStateBaseLogger, GaugePortStatsPoller, GaugeFlowTablePoller
+    from gauge_prom import GaugePortStatsPrometheusPoller
 except ImportError:
     from faucet.valve_util import dpid_log
     from faucet.gauge_influx import GaugePortStateInfluxDBLogger, GaugePortStatsInfluxDBLogger, GaugeFlowTableInfluxDBLogger
     from faucet.gauge_nsodbc import GaugeFlowTableDBLogger
     from faucet.gauge_pollers import GaugePortStateBaseLogger, GaugePortStatsPoller, GaugeFlowTablePoller
+    from faucet.gauge_prom import GaugePortStatsPrometheusPoller
 
 
 def watcher_factory(conf):
@@ -28,6 +30,7 @@ def watcher_factory(conf):
         'port_stats': {
             'text': GaugePortStatsLogger,
             'influx': GaugePortStatsInfluxDBLogger,
+            'prometheus': GaugePortStatsPrometheusPoller,
             },
         'flow_table': {
             'text': GaugeFlowTableLogger,


### PR DESCRIPTION
Note the change in official prometheus port. 9244 has been changed to 9302 to allow for gauge to use 9303 (9245 was already reserved)