### PR TITLE
Add a docker image to facilitate gNMI testing.

### DIFF
--- a/Dockerfile.gnmi
+++ b/Dockerfile.gnmi
@@ -1,0 +1,51 @@
+FROM ubuntu:16.04
+
+ENV HOME=/root
+ENV GOPATH=$HOME/go
+ENV GOBIN=$GOPATH/bin 
+ENV PATH=$GOBIN:${PATH}
+
+WORKDIR $HOME
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qy --no-install-recommends \
+      apt-utils \
+      ca-certificates \
+      software-properties-common \
+    && add-apt-repository -y ppa:longsleep/golang-backports \
+    && apt-get update
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -qy --no-install-recommends \
+    fping \
+    git \
+    golang-go \
+    iproute2 \
+    iputils-ping \
+    net-tools \
+    netcat-openbsd \
+    openssh-client \
+    psmisc \
+    sudo \
+    vim
+
+RUN mkdir -p \
+      $GOPATH \
+    && go get -u \
+      github.com/samribeiro/gnmi/gnmi_get \
+      github.com/samribeiro/gnmi/gnmi_target
+
+RUN go install -v \
+       github.com/samribeiro/gnmi/gnmi_get \
+       github.com/samribeiro/gnmi/gnmi_target
+
+COPY gnmi .
+
+RUN cd $HOME/certs/ \
+    && ./generate.sh
+
+ENV GNMI_TARGET=localhost
+ENV GNMI_PORT=32123
+ENV GNMI_QUERY="system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/state/address"
+
+CMD nohup ./run_target.sh > $HOME/target.log \
+    && /bin/bash

--- a/gnmi/README.md
+++ b/gnmi/README.md
@@ -1,0 +1,65 @@
+# gNMI
+
+A docker image that facilitates testing the gNMI protocol using Openconfig models.
+
+*  See [gNMI Protocol documentation](https://github.com/openconfig/reference/tree/master/rpc/gnmi).
+*  See [Openconfig documentation](http://www.openconfig.net/).
+
+## How to build
+
+From FAUCET root:
+
+```
+docker build -t reannz/gnmi -f Dockerfile.gnmi .
+```
+
+When building the image, a set of helper certificates is generated and added to `$HOME/certs/` folder:
+
+*  Self signed CA Certificates
+*  Client Certificates signed by the CA
+*  Server Certificates signed by the CA
+
+## How to run
+
+```
+docker run -ti reannz/gnmi:latest
+```
+
+When running the docker image a default test gNMI target is initiated:
+```
+root@090fe3d66fe7:~# cat run_target.sh 
+#!/bin/sh
+gnmi_target \
+  -bind_address :$GNMI_PORT \
+  -key $HOME/certs/server.key \
+  -cert $HOME/certs/server.crt \
+  -ca $HOME/certs/ca.crt \
+  -alsologtostderr \
+  &
+
+root@090fe3d66fe7:~# set | grep GNMI
+GNMI_PORT=32123
+GNMI_QUERY='system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/state/address'
+GNMI_TARGET=localhost
+```
+
+Run a gNMI Get:
+```
+root@090fe3d66fe7:~# cat get.sh 
+#!/bin/sh
+gnmi_get \
+  -target_address $GNMI_TARGET:$GNMI_PORT \
+  -key $HOME/certs/client.key \
+  -cert $HOME/certs/client.crt \
+  -ca $HOME/certs/ca.crt \
+  -target_name server \
+  -alsologtostderr \
+  -query $GNMI_QUERY
+```
+
+Override GNMI_TARGET, GNMI_PORT and GNMI_QUERY to perform the gNMI Get against other targets.
+
+## Used gNMI tools:
+
+*  [gNMI get](https://github.com/samribeiro/gnmi/gnmi_get)
+*  [gNMI target](https://github.com/samribeiro/gnmi/gnmi_target)

--- a/gnmi/certs/generate.sh
+++ b/gnmi/certs/generate.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+rm -f *.key *.csr *.crt *.pem *.srl
+
+SUBJ="/C=/ST=/L=/O=/CN=ca"
+
+# Generate CA Private Key
+openssl req \
+        -newkey rsa:2048 \
+        -nodes \
+        -keyout ca.key \
+        -subj $SUBJ
+
+# Generate Req
+openssl req \
+        -key ca.key \
+        -new -out ca.csr \
+        -subj $SUBJ
+
+# Generate self signed x509
+openssl x509 \
+        -signkey ca.key \
+        -in ca.csr \
+        -req \
+        -days 365 -out ca.crt 
+
+SUBJ="/C=/ST=/L=/O=/CN=server"
+
+# Generate Server Private Key
+openssl req \
+        -newkey rsa:2048 \
+        -nodes \
+        -keyout server.key \
+        -subj $SUBJ
+
+# Generate Req
+openssl req \
+        -key server.key \
+        -new -out server.csr \
+        -subj $SUBJ
+
+# Generate x509 with signed CA
+openssl x509 \
+        -req \
+        -in server.csr \
+        -CA ca.crt \
+        -CAkey ca.key \
+        -CAcreateserial \
+        -out server.crt
+
+SUBJ="/C=/ST=/L=/O=/CN=client"
+
+# Generate Client Private Key
+openssl req \
+        -newkey rsa:2048 \
+        -nodes \
+        -keyout client.key \
+        -subj $SUBJ
+
+# Generate Req
+openssl req \
+        -key client.key \
+        -new -out client.csr \
+        -subj $SUBJ
+
+# Generate x509 with signed CA
+openssl x509 \
+        -req \
+        -in client.csr \
+        -CA ca.crt \
+        -CAkey ca.key \
+        -out client.crt
+
+echo ""
+echo " == Validate Server"
+openssl verify -verbose -CAfile ca.crt server.crt
+echo ""
+echo " == Validate Client"
+openssl verify -verbose -CAfile ca.crt client.crt
+

--- a/gnmi/get.sh
+++ b/gnmi/get.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+gnmi_get \
+  -target_address $GNMI_TARGET:$GNMI_PORT \
+  -key $HOME/certs/client.key \
+  -cert $HOME/certs/client.crt \
+  -ca $HOME/certs/ca.crt \
+  -target_name server \
+  -alsologtostderr \
+  -query $GNMI_QUERY

--- a/gnmi/run_target.sh
+++ b/gnmi/run_target.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+gnmi_target \
+  -bind_address :$GNMI_PORT \
+  -key $HOME/certs/server.key \
+  -cert $HOME/certs/server.crt \
+  -ca $HOME/certs/ca.crt \
+  -alsologtostderr \
+  &


### PR DESCRIPTION
This docker contains a simple environment to test gNMI. It generates certificates for use with the provided gNMI tools. These are a gNMI Target binary and a gNMI Get binary. The gNMI Get can be used against other implementations or the existing mock gNMI Target, which for now simply returns the executed Request.