### PR TITLE
a fix for idle-timeout host refreshing

### DIFF
--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -110,8 +110,8 @@ class ValveHostManager(object):
                 if host_cache_entry_age > self.learn_timeout:
                     if not self.use_idle_timeout or host_cache_entry.expired:
                         expired_hosts.append(eth_src)
-                    else:
-                        host_cache_entry.cache_time = time.time()
+                    #else:
+                    #    host_cache_entry.cache_time = time.time()
         if expired_hosts:
             for eth_src in expired_hosts:
                 del vlan.host_cache[eth_src]

--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -3922,6 +3922,12 @@ vlans:
                 native_vlan: 100
                 description: "b4"
 """
+    def wait_for_flow_disappear(self, match, table_id=None, timeout=5):
+        for _ in range(timeout):
+            if not self.matching_flow_present(match, table_id=table_id, timeout=1):
+                return True
+        self.assertTrue(False, 'flow matching %s still exists' % match)
+
     def wait_for_flowremoved_msg(self, src_mac=None, dst_mac=None, timeout=30):
         pattern = "OFPFlowRemoved"
         mac = None
@@ -3962,11 +3968,10 @@ vlans:
             match={
                 u'in_port': int(self.port_map['port_1']),
                 u'dl_src': u'%s' % first_host.MAC()}))
-        self.assertFalse(self.matching_flow_present(
+        self.wait_for_flow_disappear(
             match={
                 u'in_port': int(self.port_map['port_2']),
-                u'dl_src': u'%s' % first_host.MAC()},
-            timeout=1))
+                u'dl_src': u'%s' % first_host.MAC()})
 
 class FaucetWithUseIdleTimeoutRuleExpiredTest(FaucetWithUseIdleTimeoutTest):
 
@@ -3979,8 +3984,8 @@ class FaucetWithUseIdleTimeoutRuleExpiredTest(FaucetWithUseIdleTimeoutTest):
         third_host, fourth_host = self.net.hosts[2:]
         self.host_ipv4_alias(first_host, ipaddress.ip_interface(u'10.99.99.1/24'))
         first_host.cmd('ping 10.0.0.2 -I 10.99.99.1 &')
-        second_host.cmd('ifconfig %s 0' % second_host.defaultIntf())
-        third_host.cmd('ifconfig %s 0' % third_host.defaultIntf())
+        for host in [second_host, third_host, fourth_host]:
+            host.cmd('ifconfig %s 0' % host.defaultIntf())
         self.wait_for_flowremoved_msg(src_mac=second_host.MAC())
         # expect to see dst rule present
         self.wait_for_host_log_msg(first_host.MAC(), 'refreshing host')
@@ -3988,19 +3993,16 @@ class FaucetWithUseIdleTimeoutRuleExpiredTest(FaucetWithUseIdleTimeoutTest):
             match={u'dl_dst': u'%s' % first_host.MAC()},
             table_id=self.ETH_DST_TABLE))
         self.wait_for_host_log_msg(second_host.MAC(), 'expiring host')
-        self.assertFalse(self.matching_flow_present(
+        self.wait_for_flow_disappear(
             match={
                 u'in_port': int(self.port_map['port_2']),
-                u'dl_src': u'%s' % second_host.MAC()},
-            timeout=2))
+                u'dl_src': u'%s' % second_host.MAC()})
         self.wait_for_host_log_msg(third_host.MAC(), 'expiring host')
-        self.assertFalse(self.matching_flow_present(
+        self.wait_for_flow_disappear(
             match={
                 u'in_port': int(self.port_map['port_3']),
-                u'dl_src': u'%s' % third_host.MAC()},
-            timeout=2))
-        self.assertFalse(self.matching_flow_present(
+                u'dl_src': u'%s' % third_host.MAC()})
+        self.wait_for_flow_disappear(
             match={u'dl_dst': u'%s' % third_host.MAC()},
-            table_id=self.ETH_DST_TABLE,
-            timeout=2))
+            table_id=self.ETH_DST_TABLE)
 


### PR DESCRIPTION
I found out the cause for the occasion of test failure. Renew cache_time during the host_expire interval causes confused that host is recently learned so the learn_host_on_vlan return empty flowmod.

Also, because dst flows stay longer than src flows, we should wait for few seconds until they are removed from tables.

I run the tests multiple times on my PC and see a consistent result.