### PR TITLE
reduce learn timeout setting in Idle-timeout test to make it reliable.

### DIFF
--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -3844,7 +3844,7 @@ vlans:
         description: "untagged"
 """
     CONFIG = """
-        timeout: 8
+        timeout: 1
         use_idle_timeout: true
         interfaces:
             %(port_1)d:


### PR DESCRIPTION
I figured out the cause for unreliable tests. The test uses timeout 8secs; this plus with a jitter, sometimes making it to 13. The idle-timeout plus 2 for dst flow, hence the dst flows timeouts at 15 sec. The test waits for flowremoved at max 15 sec making the tests fails.
I reduced the learn timeout to 1sec in tests. that solved the problem.