### PR TITLE
Make prometheus dp_id label consistent.

### DIFF
--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -173,10 +173,10 @@ class Faucet(app_manager.RyuApp):
                     self._send_flow_msgs(new_dp.dp_id, flowmods)
                     if cold_start:
                         self.metrics.faucet_config_reload_cold.labels(
-                            dpid=hex(dp_id)).inc()
+                            dp_id=hex(dp_id)).inc()
                     else:
                         self.metrics.faucet_config_reload_warm.labels(
-                            dpid=hex(dp_id)).inc()
+                            dp_id=hex(dp_id)).inc()
             else:
                 # pylint: disable=no-member
                 valve_cl = valve_factory(new_dp)
@@ -220,7 +220,7 @@ class Faucet(app_manager.RyuApp):
         for flow_msg in reordered_flow_msgs:
             # pylint: disable=no-member
             self.metrics.of_flowmsgs_sent.labels(
-                dpid=hex(dp_id)).inc()
+                dp_id=hex(dp_id)).inc()
             flow_msg.datapath = ryu_dp
             ryu_dp.send_msg(flow_msg)
 
@@ -357,7 +357,7 @@ class Faucet(app_manager.RyuApp):
 
         # pylint: disable=no-member
         self.metrics.of_packet_ins.labels(
-            dpid=hex(dp_id)).inc()
+            dp_id=hex(dp_id)).inc()
         flowmods = valve.rcv_packet(dp_id, self.valves, pkt_meta)
         self._send_flow_msgs(dp_id, flowmods)
         valve.update_metrics(self.metrics)
@@ -377,7 +377,7 @@ class Faucet(app_manager.RyuApp):
         if valve is None:
             return
         # pylint: disable=no-member
-        self.metrics.of_errors.labels(dpid=hex(dp_id)).inc()
+        self.metrics.of_errors.labels(dp_id=hex(dp_id)).inc()
         self.logger.error('OFError %s from %s', msg, dpid_log(dp_id))
 
     @set_ev_cls(ofp_event.EventOFPSwitchFeatures, CONFIG_DISPATCHER) # pylint: disable=no-member
@@ -414,8 +414,8 @@ class Faucet(app_manager.RyuApp):
             dp_id, discovered_up_port_nums)
         self._send_flow_msgs(dp_id, flowmods)
         # pylint: disable=no-member
-        self.metrics.of_dp_connections.labels(dpid=hex(dp_id)).inc()
-        self.metrics.dp_status.labels(dpid=hex(dp_id)).set(1)
+        self.metrics.of_dp_connections.labels(dp_id=hex(dp_id)).inc()
+        self.metrics.dp_status.labels(dp_id=hex(dp_id)).set(1)
 
     @kill_on_exception(exc_logname)
     def _datapath_disconnect(self, ryu_dp):
@@ -430,8 +430,8 @@ class Faucet(app_manager.RyuApp):
             return
         valve.datapath_disconnect(dp_id)
         # pylint: disable=no-member
-        self.metrics.of_dp_disconnections.labels(dpid=hex(dp_id)).inc()
-        self.metrics.dp_status.labels(dpid=hex(dp_id)).set(0)
+        self.metrics.of_dp_disconnections.labels(dp_id=hex(dp_id)).inc()
+        self.metrics.dp_status.labels(dp_id=hex(dp_id)).set(0)
 
     @set_ev_cls(dpset.EventDP, dpset.DPSET_EV_DISPATCHER)
     @kill_on_exception(exc_logname)
@@ -493,7 +493,7 @@ class Faucet(app_manager.RyuApp):
         self._send_flow_msgs(dp_id, flowmods)
         # pylint: disable=no-member
         self.metrics.port_status.labels(
-            dpid=hex(dp_id), port=port_no).set(port_status)
+            dp_id=hex(dp_id), port=port_no).set(port_status)
 
     @set_ev_cls(ofp_event.EventOFPFlowRemoved, MAIN_DISPATCHER) # pylint: disable=no-member
     @kill_on_exception(exc_logname)

--- a/faucet/faucet_bgp.py
+++ b/faucet/faucet_bgp.py
@@ -127,10 +127,10 @@ class FaucetBgp(object):
                     for neighbor, neighbor_state in neighbor_states:
                         # pylint: disable=no-member
                         self._metrics.bgp_neighbor_uptime_seconds.labels(
-                            dpid=hex(dp_id), vlan=vlan.vid, neighbor=neighbor).set(
+                            dp_id=hex(dp_id), vlan=vlan.vid, neighbor=neighbor).set(
                                 neighbor_state['info']['uptime'])
                         for ipv in vlan.ipvs():
                             # pylint: disable=no-member
                             self._metrics.bgp_neighbor_routes.labels(
-                                dpid=hex(dp_id), vlan=vlan.vid, neighbor=neighbor, ipv=ipv).set(
+                                dp_id=hex(dp_id), vlan=vlan.vid, neighbor=neighbor, ipv=ipv).set(
                                     len(vlan.routes_by_ipv(ipv)))

--- a/faucet/faucet_metrics.py
+++ b/faucet/faucet_metrics.py
@@ -28,66 +28,66 @@ class FaucetMetrics(object):
     def __init__(self, prom_port, prom_addr):
         self.of_packet_ins = Counter(
             'of_packet_ins',
-            'number of OF packet_ins received from DP', ['dpid'])
+            'number of OF packet_ins received from DP', ['dp_id'])
         self.of_flowmsgs_sent = Counter(
             'of_flowmsgs_sent',
-            'number of OF flow messages (and packet outs) sent to DP', ['dpid'])
+            'number of OF flow messages (and packet outs) sent to DP', ['dp_id'])
         self.of_errors = Counter(
             'of_errors',
-            'number of OF errors received from DP', ['dpid'])
+            'number of OF errors received from DP', ['dp_id'])
         self.of_dp_connections = Counter(
             'of_dp_connections',
-            'number of OF connections from a DP', ['dpid'])
+            'number of OF connections from a DP', ['dp_id'])
         self.of_dp_disconnections = Counter(
             'of_dp_disconnections',
-            'number of OF connections from a DP', ['dpid'])
+            'number of OF connections from a DP', ['dp_id'])
         self.faucet_config_reload_requests = Counter(
             'faucet_config_reload_requests',
             'number of config reload requests', [])
         self.faucet_config_reload_warm = Counter(
             'faucet_config_reload_warm',
             'number of warm, differences only config reloads executed',
-            ['dpid'])
+            ['dp_id'])
         self.faucet_config_reload_cold = Counter(
             'faucet_config_reload_cold',
             'number of cold, complete reprovision config reloads executed',
-            ['dpid'])
+            ['dp_id'])
         self.vlan_hosts_learned = Gauge(
             'vlan_hosts_learned',
-            'number of hosts learned on a VLAN', ['dpid', 'vlan'])
+            'number of hosts learned on a VLAN', ['dp_id', 'vlan'])
         self.vlan_neighbors = Gauge(
             'vlan_neighbors',
-            'number of neighbors on a VLAN', ['dpid', 'vlan', 'ipv'])
+            'number of neighbors on a VLAN', ['dp_id', 'vlan', 'ipv'])
         self.vlan_learn_bans = Gauge(
             'vlan_learn_bans',
-            'number of times learning was banned on a VLAN', ['dpid', 'vlan'])
+            'number of times learning was banned on a VLAN', ['dp_id', 'vlan'])
         self.faucet_config_table_names = Gauge(
             'faucet_config_table_names',
-            'number to names map of FAUCET pipeline tables', ['dpid', 'name'])
+            'number to names map of FAUCET pipeline tables', ['dp_id', 'name'])
         self.faucet_config_dp_name = Gauge(
             'faucet_config_dp_name',
-            'map of DP name to DP ID', ['dpid', 'name'])
+            'map of DP name to DP ID', ['dp_id', 'name'])
         self.bgp_neighbor_uptime_seconds = Gauge(
             'bgp_neighbor_uptime',
-            'BGP neighbor uptime in seconds', ['dpid', 'vlan', 'neighbor'])
+            'BGP neighbor uptime in seconds', ['dp_id', 'vlan', 'neighbor'])
         self.bgp_neighbor_routes = Gauge(
             'bgp_neighbor_routes',
-            'BGP neighbor route count', ['dpid', 'vlan', 'neighbor', 'ipv'])
+            'BGP neighbor route count', ['dp_id', 'vlan', 'neighbor', 'ipv'])
         self.learned_macs = Gauge(
             'learned_macs',
             ('max address stored as 64bit number to DP ID, port, VLAN, '
              'and n (maximum number of hosts on the port)'),
-            ['dpid', 'port', 'vlan', 'n'])
+            ['dp_id', 'port', 'vlan', 'n'])
         self.port_status = Gauge(
             'port_status',
             'status of switch ports',
-            ['dpid', 'port'])
+            ['dp_id', 'port'])
         self.port_learn_bans = Gauge(
             'port_learn_bans',
             'number of times learning was banned on a port',
-            ['dpid', 'port'])
+            ['dp_id', 'port'])
         self.dp_status = Gauge(
             'dp_status',
             'status of datapaths',
-            ['dpid'])
+            ['dp_id'])
         start_http_server(prom_port, prom_addr)

--- a/faucet/gauge.py
+++ b/faucet/gauge.py
@@ -169,7 +169,7 @@ class Gauge(app_manager.RyuApp):
         dp_id = ryu_dp.id
         if dp_id in self.watchers:
             self.logger.info('%s up', dpid_log(dp_id))
-            self.prom_client.dp_status.labels(dpid=hex(dp_id)).set(1)
+            self.prom_client.dp_status.labels(dp_id=hex(dp_id)).set(1)
             for watcher in list(self.watchers[dp_id].values()):
                 self.logger.info(
                     '%s %s watcher starting', dpid_log(dp_id), watcher.conf.type)
@@ -187,7 +187,7 @@ class Gauge(app_manager.RyuApp):
         dp_id = ryu_dp.id
         if dp_id in self.watchers:
             self.logger.info('%s down', dpid_log(dp_id))
-            self.prom_client.dp_status.labels(dpid=hex(dp_id)).set(0)
+            self.prom_client.dp_status.labels(dp_id=hex(dp_id)).set(0)
             for watcher in list(self.watchers[dp_id].values()):
                 self.logger.info(
                     '%s %s watcher stopping', dpid_log(dp_id), watcher.conf.type)

--- a/faucet/gauge_prom.py
+++ b/faucet/gauge_prom.py
@@ -45,7 +45,7 @@ class GaugePrometheusClient(object):
         self.dp_status = PromGauge(
             'dp_status',
             'status of datapaths',
-            ['dpid'])
+            ['dp_id'])
         for prom_var in PROM_PORT_VARS:
             exported_prom_var = PROM_PREFIX_DELIM.join(
                 (PROM_PORT_PREFIX, prom_var))

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1008,7 +1008,7 @@ class Valve(object):
         metrics (FaucetMetrics): container of Prometheus metrics.
         """
         metrics.faucet_config_dp_name.labels(
-            dpid=hex(self.dp.dp_id), name=self.dp.name).set(
+            dp_id=hex(self.dp.dp_id), name=self.dp.name).set(
                 self.dp.dp_id)
         for table_name, table_id in (
                 ('port_acl', self.dp.port_acl_table),
@@ -1021,7 +1021,7 @@ class Valve(object):
                 ('eth_dst', self.dp.eth_dst_table),
                 ('flood', self.dp.flood_table)):
             metrics.faucet_config_table_names.labels(
-                dpid=hex(self.dp.dp_id), name=table_name).set(table_id)
+                dp_id=hex(self.dp.dp_id), name=table_name).set(table_id)
 
     def update_metrics(self, metrics):
         """Update Gauge/metrics.
@@ -1029,24 +1029,24 @@ class Valve(object):
         metrics (FaucetMetrics or None): container of Prometheus metrics.
         """
         # Clear the exported MAC learning.
-        dpid = hex(self.dp.dp_id)
+        dp_id = hex(self.dp.dp_id)
         for _, label_dict, _ in metrics.learned_macs.collect()[0].samples:
-            if label_dict['dpid'] == dpid:
+            if label_dict['dp_id'] == dp_id:
                 metrics.learned_macs.labels(
-                    dpid=label_dict['dpid'], vlan=label_dict['vlan'],
+                    dp_id=label_dict['dp_id'], vlan=label_dict['vlan'],
                     port=label_dict['port'], n=label_dict['n']).set(0)
 
         for vlan in list(self.dp.vlans.values()):
             hosts_count = self.host_manager.hosts_learned_on_vlan_count(
                 vlan)
             metrics.vlan_hosts_learned.labels(
-                dpid=dpid, vlan=vlan.vid).set(hosts_count)
+                dp_id=dp_id, vlan=vlan.vid).set(hosts_count)
             metrics.vlan_learn_bans.labels(
-                dpid=dpid, vlan=vlan.vid).set(vlan.learn_ban_count)
+                dp_id=dp_id, vlan=vlan.vid).set(vlan.learn_ban_count)
             for ipv in vlan.ipvs():
                 neigh_cache_size = len(vlan.neigh_cache_by_ipv(ipv))
                 metrics.vlan_neighbors.labels(
-                    dpid=dpid, vlan=vlan.vid, ipv=ipv).set(neigh_cache_size)
+                    dp_id=dp_id, vlan=vlan.vid, ipv=ipv).set(neigh_cache_size)
             # Repopulate MAC learning.
             hosts_on_port = {}
             for eth_src, host_cache_entry in sorted(list(vlan.host_cache.items())):
@@ -1058,11 +1058,11 @@ class Valve(object):
             for port_num, hosts in list(hosts_on_port.items()):
                 for i, mac_int in enumerate(hosts):
                     metrics.learned_macs.labels(
-                        dpid=dpid, vlan=vlan.vid,
+                        dp_id=dp_id, vlan=vlan.vid,
                         port=port_num, n=i).set(mac_int)
             for port in list(self.dp.ports.values()):
                 metrics.port_learn_bans.labels(
-                    dpid=dpid, port=port.number).set(port.learn_ban_count)
+                    dp_id=dp_id, port=port.number).set(port.learn_ban_count)
 
 
     def rcv_packet(self, dp_id, valves, pkt_meta):

--- a/tests/faucet_mininet_test_base.py
+++ b/tests/faucet_mininet_test_base.py
@@ -773,7 +773,7 @@ dbs:
         if labels is None:
             labels = {}
         if dpid:
-            labels.update({'dpid': '0x%x' % long(self.dpid)})
+            labels.update({'dp_id': '0x%x' % long(self.dpid)})
         if labels:
             label_values = []
             for label, value in sorted(list(labels.items())):


### PR DESCRIPTION
Gauge uses dp_id rather than dpid for prometheus labels.

Tests passing - https://travis-ci.org/gizmoguy/faucet/builds/269856691