### PR TITLE
Add version info to faucet.__all__.

### DIFF
--- a/faucet/__init__.py
+++ b/faucet/__init__.py
@@ -1,0 +1,8 @@
+# pylint: disable=missing-docstring
+from pbr.version import VersionInfo
+
+__all__ = (
+    '__version__',
+)
+
+__version__ = VersionInfo('faucet').semantic_version().release_string()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ influxdb
 ipaddress
 networkx
 numpy
+pbr>=1.9
 prometheus_client
 pyyaml
 ryu==4.16


### PR DESCRIPTION
This PR will provide the running version of faucet (in faucet.__version__) by using PBR to parse the version info.

Tests passing - https://travis-ci.org/gizmoguy/faucet/builds/271654005